### PR TITLE
fix(pkg-configs): declare host_data_prepare_requirements for host-side data prep (#12–#18)

### DIFF
--- a/vendor/pkg_configs/CFGpp-main/config.json
+++ b/vendor/pkg_configs/CFGpp-main/config.json
@@ -38,7 +38,14 @@
     "python -c \"import torch, diffusers, clip; print('CFGpp local deps OK')\""
   ],
 
-  "host_data_prepare_requirements": ["pytorch-fid"],
+  "host_data_prepare_requirements": [
+    "huggingface-hub==0.23.3",
+    "numpy==1.24.3",
+    "torch==2.2.2",
+    "torchvision==0.17.2",
+    "pillow==9.5.0",
+    "pytorch-fid==0.3.0"
+  ],
   "data_bind": [
     "{data_root}/huggingface_cache:/data/huggingface",
     "{data_root}/coco_val2014:/data/coco_val2014",

--- a/vendor/pkg_configs/ClimSim/config.json
+++ b/vendor/pkg_configs/ClimSim/config.json
@@ -1,6 +1,6 @@
 {
   "base_image": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel",
-  "host_data_prepare_requirements": ["xarray", "netCDF4", "huggingface_hub"],
+  "host_data_prepare_requirements": ["xarray", "netCDF4", "huggingface_hub", "numpy"],
   "data_deps": [
     {
       "name": "climsim",

--- a/vendor/pkg_configs/EHIGN_PLA/config.json
+++ b/vendor/pkg_configs/EHIGN_PLA/config.json
@@ -1,5 +1,9 @@
 {
   "base_image": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel",
+  "host_data_prepare_requirements": [
+    "torch",
+    "gdown"
+  ],
   "data_deps": [
     {
       "name": "ehign-pla",

--- a/vendor/pkg_configs/HypSeek/config.json
+++ b/vendor/pkg_configs/HypSeek/config.json
@@ -1,6 +1,9 @@
 {
   "base_image": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel",
   "verify_existing_data": true,
+  "host_data_prepare_requirements": [
+    "gdown"
+  ],
   "data_deps": [
     {
       "name": "hypseek-pretrain",

--- a/vendor/pkg_configs/LLaDA/config.json
+++ b/vendor/pkg_configs/LLaDA/config.json
@@ -15,6 +15,9 @@
     "LLADA_INSTRUCT_PATH": "/data/llada-instruct",
     "PYTHONPATH": "/workspace/LLaDA:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub>=0.20"
+  ],
   "data_deps": [
     {
       "name": "llada-instruct",

--- a/vendor/pkg_configs/Neural-Solver-Library/config.json
+++ b/vendor/pkg_configs/Neural-Solver-Library/config.json
@@ -1,5 +1,9 @@
 {
   "base_image": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel",
+  "host_data_prepare_requirements": [
+    "gdown",
+    "h5py"
+  ],
   "data_deps": [
     {
       "name": "neural-solver-library",

--- a/vendor/pkg_configs/Time-Series-Library/config.json
+++ b/vendor/pkg_configs/Time-Series-Library/config.json
@@ -18,6 +18,9 @@
   "writable_tmpfs": true,
   "no_home": true,
   "workdir": "/workspace",
+  "host_data_prepare_requirements": [
+    "huggingface_hub"
+  ],
   "data_deps": [
     {
       "name": "tslib_datasets",

--- a/vendor/pkg_configs/continual-learning/config.json
+++ b/vendor/pkg_configs/continual-learning/config.json
@@ -3,6 +3,9 @@
   "install_cmds": [
     "pip install numpy torchvision matplotlib tqdm"
   ],
+  "host_data_prepare_requirements": [
+    "torchvision"
+  ],
   "data_deps": [
     {
       "name": "continual_learning_datasets",

--- a/vendor/pkg_configs/dLLM-cache/config.json
+++ b/vendor/pkg_configs/dLLM-cache/config.json
@@ -22,8 +22,8 @@
     "{data_root}/huggingface_cache:/data/huggingface"
   ],
   "host_data_prepare_requirements": [
-    "huggingface_hub",
-    "datasets"
+    "huggingface_hub==0.26.2",
+    "datasets==3.1.0"
   ],
   "data_deps": [
     {

--- a/vendor/pkg_configs/dLLM-cache/config.json
+++ b/vendor/pkg_configs/dLLM-cache/config.json
@@ -21,6 +21,10 @@
   "data_bind": [
     "{data_root}/huggingface_cache:/data/huggingface"
   ],
+  "host_data_prepare_requirements": [
+    "huggingface_hub",
+    "datasets"
+  ],
   "data_deps": [
     {
       "name": "LLaDA-8B-Instruct",

--- a/vendor/pkg_configs/easy-few-shot-learning/config.json
+++ b/vendor/pkg_configs/easy-few-shot-learning/config.json
@@ -12,6 +12,10 @@
     "{data_root}/CUB:/data/CUB",
     "{data_root}/cifar_fs:/data/cifar_fs"
   ],
+  "host_data_prepare_requirements": [
+    "numpy",
+    "Pillow"
+  ],
   "data_deps": [
     {
       "name": "mini_imagenet",

--- a/vendor/pkg_configs/gptq/config.json
+++ b/vendor/pkg_configs/gptq/config.json
@@ -14,6 +14,10 @@
     "HF_DATASETS_CACHE": "/data/wikitext2",
     "PYTHONPATH": "/workspace/gptq:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub",
+    "datasets"
+  ],
   "data_deps": [
     {
       "name": "mistral-7b-v01",

--- a/vendor/pkg_configs/gptq/config.json
+++ b/vendor/pkg_configs/gptq/config.json
@@ -15,8 +15,8 @@
     "PYTHONPATH": "/workspace/gptq:${PYTHONPATH}"
   },
   "host_data_prepare_requirements": [
-    "huggingface_hub",
-    "datasets"
+    "huggingface_hub==0.26.2",
+    "datasets==3.1.0"
   ],
   "data_deps": [
     {

--- a/vendor/pkg_configs/llm-qat-runtime/config.json
+++ b/vendor/pkg_configs/llm-qat-runtime/config.json
@@ -14,6 +14,10 @@
     "HF_DATASETS_CACHE": "/data/wikitext2",
     "PYTHONPATH": "/workspace/llm-qat-runtime:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub",
+    "datasets"
+  ],
   "data_deps": [
     {
       "name": "pythia-1.4b",

--- a/vendor/pkg_configs/llm-qat-runtime/config.json
+++ b/vendor/pkg_configs/llm-qat-runtime/config.json
@@ -15,8 +15,8 @@
     "PYTHONPATH": "/workspace/llm-qat-runtime:${PYTHONPATH}"
   },
   "host_data_prepare_requirements": [
-    "huggingface_hub",
-    "datasets"
+    "huggingface_hub==0.26.2",
+    "datasets==3.1.0"
   ],
   "data_deps": [
     {

--- a/vendor/pkg_configs/lm-evaluation-harness/config.json
+++ b/vendor/pkg_configs/lm-evaluation-harness/config.json
@@ -33,6 +33,7 @@
   },
   "host_data_prepare_requirements": [
     "datasets<3.0",
+    "huggingface-hub<1.0",
     "lm-eval>=0.4.0",
     "tiktoken"
   ],

--- a/vendor/pkg_configs/nanoGPT/config.json
+++ b/vendor/pkg_configs/nanoGPT/config.json
@@ -36,7 +36,7 @@
     "datasets<3.0",
     "lm-eval>=0.4.0",
     "tiktoken",
-    "huggingface_hub",
+    "huggingface-hub<1.0",
     "numpy"
   ],
   "env": {

--- a/vendor/pkg_configs/pytorch-vision/config.json
+++ b/vendor/pkg_configs/pytorch-vision/config.json
@@ -11,6 +11,9 @@
   "env": {
     "PYTHONPATH": "/workspace/pytorch-vision:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "torchvision==0.20.1"
+  ],
   "data_deps": [
     {
       "name": "pytorch-vision-data",

--- a/vendor/pkg_configs/scikit-learn/config.json
+++ b/vendor/pkg_configs/scikit-learn/config.json
@@ -23,6 +23,13 @@
   "env": {
     "SKLEARN_DATA_HOME": "/data/sklearn"
   },
+  "host_data_prepare_requirements": [
+    "scikit-learn==1.5.2",
+    "numpy",
+    "scipy",
+    "pandas",
+    "aif360==0.6.1"
+  ],
   "data_deps": [
     {
       "name": "sklearn_datasets",

--- a/vendor/pkg_configs/sparse-attn-eval/config.json
+++ b/vendor/pkg_configs/sparse-attn-eval/config.json
@@ -15,6 +15,10 @@
     "HF_DATASETS_CACHE": "/data/longctx",
     "PYTHONPATH": "/workspace/sparse-attn-eval:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub==0.26.2",
+    "datasets==3.1.0"
+  ],
   "data_deps": [
     {
       "name": "qwen2.5-1.5b-instruct",

--- a/vendor/pkg_configs/torchattacks/config.json
+++ b/vendor/pkg_configs/torchattacks/config.json
@@ -14,6 +14,11 @@
     "TORCH_HOME": "/data/torch_cache"
   },
   "data_bind": "{data_root}/torchattacks:/data",
+  "host_data_prepare_requirements": [
+    "torch",
+    "torchvision",
+    "gdown"
+  ],
   "data_deps": [
     {
       "name": "torchattacks-data",

--- a/vendor/pkg_configs/transformers-kv-lab/config.json
+++ b/vendor/pkg_configs/transformers-kv-lab/config.json
@@ -21,6 +21,10 @@
     "TORCH_HOME": "/data/huggingface/torch",
     "XDG_CACHE_HOME": "/data/huggingface"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub",
+    "datasets"
+  ],
   "data_deps": [
     {
       "name": "transformers-kv-lab-hf-cache",

--- a/vendor/pkg_configs/verl/config.json
+++ b/vendor/pkg_configs/verl/config.json
@@ -14,6 +14,12 @@
     "XDG_CONFIG_HOME": "/tmp/config"
   },
   "apptainer_flags": ["--contain"],
+  "host_data_prepare_requirements": [
+    "huggingface_hub",
+    "datasets",
+    "pandas",
+    "pyarrow"
+  ],
   "data_deps": [
     {
       "name": "Qwen3-1.7B",


### PR DESCRIPTION
## Problem

`mlsbench data <pkg>` runs each `data_deps[].prepare` script **on the host** (under docker/apptainer), starting from the base install (`pyyaml` + `packaging`) and installing only what the package declares in `host_data_prepare_requirements`. That key was only ever populated for `lm-evaluation-harness` and `nanoGPT`, so every other package whose prepare script imports a third-party library (`huggingface_hub`, `datasets`, `scikit-learn`, `aif360`, `torch`, …) fails with `ModuleNotFoundError` on a fresh clone — exactly the failures reported in #12–#18.

## Fix

Two commits:

**1. Declare `host_data_prepare_requirements` everywhere it's missing.** Swept **every** `vendor/pkg_configs/*/config.json` with `data_deps[].prepare` scripts and declared the exact third-party imports, version-pinned to match each package's own `install_cmds`. Packages whose prepare scripts use only stdlib + base deps (e.g. `alphaflow-main`, `diffusers-main`, `gsplat`, `ProteinGym`, `Uni-Mol`, …) correctly need no declaration and are unchanged.

**2. Pin hf-hub<1.0 + datasets<4 for the bare-name dataset preps** (`gptq`, `llm-qat-runtime`, `dLLM-cache`). These load **bare (non-namespaced)** HF datasets (`wikitext`, `openai_humaneval`). `huggingface_hub` **1.x rejects bare repo ids** — `Invalid HF URI 'hf://datasets/wikitext@…/README.md'. Repository id must be 'namespace/name'` — *independent of the datasets version*, and `datasets` 4.x dropped `trust_remote_code`. Pinned to the tested `huggingface_hub==0.26.2` + `datasets==3.1.0` (the same stack `sparse-attn-eval` already uses). This is the same class as the lm-eval failure in #14 (which pins `huggingface-hub<1.0` alongside `datasets<3.0`).

Namespaced-only preps (`verl`, `LLaMA-Factory`, `Unify-Post-Training`, `transformers-kv-lab`, `trl`) load fine with hf-hub 1.x and are intentionally left unpinned. `install_cmds` are untouched (host-side requirements are sufficient for the reported `mlsbench data` failures).

## Testing

Verified in clean Python 3.10 venvs (mirror a fresh clone). Crucially, the **actual prepare scripts** were run, not proxies:

1. **Reproduction** — every prepare-script import fails with `ModuleNotFoundError` on the base install.
2. **Resolution** — all unique requirement sets `pip install --dry-run` resolve with zero conflicts (incl. `scikit-learn==1.5.2` + `aif360==0.6.1`, `datasets==3.1.0` + `huggingface-hub==0.26.2`, `torch==2.2.2` + `torchvision==0.17.2` + `pytorch-fid==0.3.0`).
3. **Runtime — bare-name datasets (the #14/#17/#18 class):**
   - `lm-evaluation-harness/prepare_datasets.py` reproduces the reported error verbatim with hf-hub `1.17.0` (`Invalid HF URI '…hellaswag…'`) and **succeeds** with `huggingface-hub<1.0`.
   - `gptq` / `llm-qat-runtime` `prepare_wikitext2.py`: **FAIL** with datasets 4.8.5 + hf-hub 1.17 (`…wikitext…`), **succeed** with 3.1.0 + 0.26.2 (train 36718 / test 4358).
   - `dLLM-cache/prepare_hf_datasets.py`: **FAIL** with hf-hub 1.17 (`…openai_humaneval…`), **succeed** with 3.1.0 + 0.26.2 (humaneval 164 + ai2_arc).
4. **Runtime — scikit-learn (#12):** real `prepare_data.py` runs end-to-end with `scikit-learn 1.5.2` + `aif360 0.6.1` (mnist/Fashion-MNIST/madelon/20newsgroups/california_housing OK; AIF360 `adult`/`compas`/`law_school` OK).
5. **Namespaced-only safety:** `openai/gsm8k` / `AI-MO/aimo-validation-amc` full-load OK with datasets 4.x + hf-hub 1.17 — confirms leaving the namespaced-only packages unpinned is correct.

Fixes #12, #13, #14, #15, #16, #17, #18.
