### PR TITLE
fix(pkg-configs): declare host_data_prepare_requirements for robomimic (#20)

### DIFF
--- a/vendor/pkg_configs/robomimic/config.json
+++ b/vendor/pkg_configs/robomimic/config.json
@@ -18,6 +18,9 @@
     "PYTHONPATH": "/workspace/robomimic:${PYTHONPATH}",
     "DATASET_ROOT": "/data/datasets"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub"
+  ],
   "data_deps": [
     {
       "name": "transport-ph",


### PR DESCRIPTION
## Problem

`mlsbench data robomimic` fails on a fresh clone with `ModuleNotFoundError: huggingface_hub`. robomimic's prepare scripts (`download_transport.py` / `download_tool_hang.py` / `download_can.py` / `download_square.py` and `prepare_clip.py`) all import `huggingface_hub` to fetch the demo datasets and CLIP weights, but the host-side declaration — present in the source tree — was never carried into the released config. This is the same class fixed in #19; robomimic was the one package whose declaration already existed upstream and so wasn't part of that diff.

## Fix

```json
"host_data_prepare_requirements": [
  "huggingface_hub"
]
```

`huggingface_hub` is the complete requirement: the prepare scripts import only `huggingface_hub` (+ stdlib), and all repos they fetch are namespaced, so no version pin is needed (namespaced loads work fine with hf-hub 1.x, unlike the bare-name datasets handled in #19).

Fixes #20.