### PR TITLE
fix(pytorch-vision): declare torch explicitly in host_data_prepare_requirements

### DIFF
--- a/vendor/pkg_configs/pytorch-vision/config.json
+++ b/vendor/pkg_configs/pytorch-vision/config.json
@@ -12,6 +12,7 @@
     "PYTHONPATH": "/workspace/pytorch-vision:${PYTHONPATH}"
   },
   "host_data_prepare_requirements": [
+    "torch==2.5.1",
     "torchvision==0.20.1"
   ],
   "data_deps": [


### PR DESCRIPTION
Follow-up to #22.

The host-side data-prep requirement for `pytorch-vision` was added in #19 (`torchvision==0.20.1`), which already resolves the reported `ModuleNotFoundError: No module named 'torchvision'` — `pip install torchvision==0.20.1` pulls `torch==2.5.1` transitively (the wheel hard-pins it).

This follow-up lists `torch==2.5.1` explicitly as well, per the reporter's suggestion: it's clearer about intent and guards against host-env drift. Versions match the package runtime stack (`pytorch/pytorch:2.5.1-...` + `torchvision==0.20.1`).

No functional change for a fresh clone; purely makes the dependency explicit.