### PR TITLE
harbor-adapter: durability fixes for #25 (manifest skip-list, task data staging, _task eval symlink)

### DIFF
--- a/harbor_adapter/src/mls_bench/adapter.py
+++ b/harbor_adapter/src/mls_bench/adapter.py
@@ -1525,6 +1525,17 @@ def _stage_pristine_assets(
             if not _stat.S_ISREG(st.st_mode):
                 continue
             rel = fp.relative_to(scaffold_dir).as_posix()
+            # Keep in sync with the package-source walk + the verifier's
+            # _SKIP_SUFFIXES: a scaffold-only .so/.o/.egg-info entry would
+            # otherwise be emitted into the manifest while the verifier's
+            # _walk_workspace skips it, yielding a spurious deleted-file
+            # violation (issue #25.2 Error-2, Codex P2 on #29).
+            rel_parts = rel.split("/")
+            if any(part in (".git", "__pycache__") for part in rel_parts):
+                continue
+            if any(part.endswith(suf) for part in rel_parts
+                   for suf in (".pyc", ".pyo", ".so", ".o", ".egg-info")):
+                continue
             scaffold_index[rel] = fp
 
     declared_files = {

--- a/harbor_adapter/src/mls_bench/adapter.py
+++ b/harbor_adapter/src/mls_bench/adapter.py
@@ -1426,6 +1426,20 @@ def _stage_verifier_assets(
     if scripts_src.exists():
         shutil.copytree(scripts_src, tests_dir / "eval" / "scripts", dirs_exist_ok=True)
 
+    # Task-bundled eval data (e.g. llm-dllm-demask-strategy ships math_test.json /
+    # c4_texts.json / HumanEval.jsonl.gz / klass_utils.py under tasks/<t>/data/).
+    # Native MLSBench bind-mounts the task dir at /workspace/_task so eval scripts
+    # read it as /workspace/_task/data/...; Harbor has no bind mounts, so stage it
+    # into tests/meta/data/ where score_task.py exposes it via the /workspace/_task
+    # symlink at eval time (issue #25.4).
+    data_src = task_dir / "data"
+    if data_src.exists():
+        shutil.copytree(
+            data_src, meta / "data",
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+
     # Task-bundled third-party resources (e.g. dlm-dkv-policy ships pristine
     # snapshots of upstream dLLM-cache / D2Cache / Elastic-Cache LLaDA model
     # code under tasks/<t>/third_party/). These are loaded at verify time
@@ -1569,9 +1583,15 @@ def _stage_pristine_assets(
             except ValueError:
                 continue
             # Skip metadata noise that's never part of agent-visible workspace.
-            if any(part in (".git", "__pycache__") for part in fp.relative_to(pkg_src).parts):
+            # MUST stay in sync with score_task.py::_SKIP_SUFFIXES — the verifier's
+            # _walk_workspace skips .pyc/.pyo/.so/.o/.egg-info, so any such entry
+            # left in the manifest is never walked and the guard reports it as a
+            # spurious 'deleted file' (issue #25.2 Error-2).
+            rel_parts = fp.relative_to(pkg_src).parts
+            if any(part in (".git", "__pycache__") for part in rel_parts):
                 continue
-            if fp.suffix in (".pyc", ".pyo"):
+            if any(part.endswith(suf) for part in rel_parts
+                   for suf in (".pyc", ".pyo", ".so", ".o", ".egg-info")):
                 continue
             sub = fp.relative_to(pkg_src).as_posix()
             rel = f"{pkg}/{sub}" if sub else pkg

--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -793,6 +793,23 @@ def _remove_budget_legacy_links(links: list[Path]) -> None:
             pass
 
 
+def _build_eval_task_dir(task_meta: Path) -> Path:
+    """Throwaway dir exposing ONLY the eval-time resources (scripts/ data/
+    third_party/) that some eval wrappers reach via /workspace/_task. It
+    deliberately EXCLUDES the scoring metadata (parser.py / score_spec.py /
+    config.json / leaderboard.csv) that cmd_score imports: eval runs agent-
+    authored package code as root, so any path it can reach is writable (chmod
+    a-w doesn't stop root), and exposing the real task_meta would let a
+    submission overwrite the parser/spec before the score phase. The real
+    task_meta stays at its unexposed random /tmp path."""
+    d = Path(tempfile.mkdtemp(prefix="mlsbench-evaltask-"))
+    for sub in ("scripts", "data", "third_party"):
+        src = task_meta / sub
+        if src.exists():
+            shutil.copytree(src, d / sub, dirs_exist_ok=True)
+    return d
+
+
 def _run_budget_check(
     *,
     task_meta: Path,
@@ -1185,15 +1202,18 @@ def cmd_run_evals(args: argparse.Namespace) -> int:
             if not runnable_tasks:
                 continue
 
-            # Expose tests/meta at the legacy /workspace/_task path that some
-            # eval wrappers reference (humanoid: `python _task/scripts/...`;
-            # dllm: `--data-path /workspace/_task/data/...`). Native MLSBench
-            # bind-mounts the task dir there, but Harbor has no bind mounts, so
-            # symlink the (read-only) task_meta — which ships scripts/ and data/
-            # — for the duration of the eval wave. The guard exempts the _task
-            # top-level dir and runs as a separate pre-eval invocation, so this
-            # never affects the edit-range diff. (issue #25.4, #25.5)
-            eval_task_links = _install_budget_legacy_links(task_meta, workspace_root)
+            # Expose the legacy /workspace/_task path that some eval wrappers
+            # reference (humanoid: `python _task/scripts/...`; dllm:
+            # `--data-path /workspace/_task/data/...`). Native MLSBench bind-mounts
+            # the task dir there, but Harbor has no bind mounts. We point _task at
+            # a MINIMAL throwaway copy (scripts/data/third_party only) rather than
+            # task_meta, so eval-time agent code (running as root) cannot reach and
+            # overwrite the scoring metadata (parser.py/score_spec.py/config.json)
+            # before the score phase. The guard exempts the _task top-level dir and
+            # runs as a separate pre-eval invocation, so this never affects the
+            # diff. (issue #25.4, #25.5; Codex P1 on #29)
+            eval_task_dir = _build_eval_task_dir(task_meta)
+            eval_task_links = _install_budget_legacy_links(eval_task_dir, workspace_root)
             try:
                 wave_results = _run_eval_wave(
                     tasks=runnable_tasks,
@@ -1205,6 +1225,7 @@ def cmd_run_evals(args: argparse.Namespace) -> int:
                 )
             finally:
                 _remove_budget_legacy_links(eval_task_links)
+                shutil.rmtree(eval_task_dir, ignore_errors=True)
             records.update(wave_results)
             for task in runnable_tasks:
                 entry = task["entry"]

--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -1160,14 +1160,26 @@ def cmd_run_evals(args: argparse.Namespace) -> int:
             if not runnable_tasks:
                 continue
 
-            wave_results = _run_eval_wave(
-                tasks=runnable_tasks,
-                assignments=runnable_assignments,
-                task_meta=task_meta,
-                workspace_root=workspace_root,
-                default_pkg=default_pkg,
-                out_dir=out_dir,
-            )
+            # Expose tests/meta at the legacy /workspace/_task path that some
+            # eval wrappers reference (humanoid: `python _task/scripts/...`;
+            # dllm: `--data-path /workspace/_task/data/...`). Native MLSBench
+            # bind-mounts the task dir there, but Harbor has no bind mounts, so
+            # symlink the (read-only) task_meta — which ships scripts/ and data/
+            # — for the duration of the eval wave. The guard exempts the _task
+            # top-level dir and runs as a separate pre-eval invocation, so this
+            # never affects the edit-range diff. (issue #25.4, #25.5)
+            eval_task_links = _install_budget_legacy_links(task_meta, workspace_root)
+            try:
+                wave_results = _run_eval_wave(
+                    tasks=runnable_tasks,
+                    assignments=runnable_assignments,
+                    task_meta=task_meta,
+                    workspace_root=workspace_root,
+                    default_pkg=default_pkg,
+                    out_dir=out_dir,
+                )
+            finally:
+                _remove_budget_legacy_links(eval_task_links)
             records.update(wave_results)
             for task in runnable_tasks:
                 entry = task["entry"]

--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -228,7 +228,23 @@ def _is_workspace_guard_exempt(rel: Path) -> bool:
     return bool(rel.parts and rel.parts[0] in _EXEMPT_TOP_LEVEL_DIRS)
 
 
-def _walk_workspace(workspace_root: Path) -> set[Path]:
+def _is_path_excluded(rel: Path, excludes: tuple) -> bool:
+    """True if *rel* (workdir-relative) is under a config ``guard_exclude`` prefix.
+
+    Lets a task drop image-baked data dirs (datasets / weights / caches that the
+    package install bakes INSIDE the package dir, e.g. ``dbim-codebase/assets``)
+    out of the guard: they are not the agent's editable source surface, the
+    render-time manifest never captured them, and walking them would otherwise
+    flag every baked file as a spurious ``created``/``modified`` violation
+    (issue #25.2 Error-1/Error-3). POSIX path-prefix match.
+    """
+    if not excludes:
+        return False
+    rp = rel.as_posix()
+    return any(rp == e or rp.startswith(e + "/") for e in excludes)
+
+
+def _walk_workspace(workspace_root: Path, excludes: tuple = ()) -> set[Path]:
     out: set[Path] = set()
     if not workspace_root.exists():
         return out
@@ -241,6 +257,8 @@ def _walk_workspace(workspace_root: Path) -> set[Path]:
             continue
         rel = p.relative_to(workspace_root)
         if _is_workspace_guard_exempt(rel):
+            continue
+        if _is_path_excluded(rel, excludes):
             continue
         out.add(rel)
     return out
@@ -285,8 +303,13 @@ def cmd_guard(args: argparse.Namespace) -> int:
 
     editable = _editable_files(config)
     allow_create = bool(config.get("allow_create", False))
+    # Optional per-task allowlist of workdir-relative prefixes dropped from the
+    # guard — for image-baked data/build dirs inside the package dir that aren't
+    # the agent's editable surface and were never in the render-time manifest
+    # (issue #25.2 Error-1/Error-3).
+    guard_exclude = tuple(config.get("guard_exclude", []) or [])
 
-    workspace_files = _walk_workspace(workspace_root)
+    workspace_files = _walk_workspace(workspace_root, guard_exclude)
     workspace_rel_strs = {p.as_posix() for p in workspace_files}
 
     # Guarded prefixes: every top-level dir referenced by editable list AND
@@ -308,6 +331,8 @@ def cmd_guard(args: argparse.Namespace) -> int:
     for rel_str in sorted(manifest):
         rel = Path(rel_str)
         if not rel.parts or rel.parts[0] not in guarded_prefixes:
+            continue
+        if _is_path_excluded(rel, guard_exclude):
             continue
         if rel_str in workspace_rel_strs:
             continue


### PR DESCRIPTION
Companion to #28 (which fixes the **already-rendered** bundles on `main`). This patches the **adapter** so re-rendering doesn't reintroduce the bugs.

- `_stage_pristine_assets`: skip `.so/.o/.egg-info` in the manifest builder to match the verifier's `_SKIP_SUFFIXES` (#25.2 Error-2 — spurious `deleted file`).
- `_stage_verifier_assets`: copy `tasks/<t>/data/` into `tests/meta/data/` (Harbor has no bind mounts; reached at eval via the `/workspace/_task` symlink) (#25.4).
- `task-template/tests/score_task.py`: `cmd_run_evals` symlinks the read-only `task_meta` to `/workspace/_task` around each eval wave (#25.4/#25.5).

**Tested** by re-rendering 3 affected tasks: `llm-dllm-demask-strategy` (`tests/meta/data/` now staged with all 4 files), `robo-humanoid-sim2real-algo` (`score_task.py` has the symlink), `causal-observational-nonlinear` (manifest has 0 `.so/.o/.egg-info` entries, 673 total).

(#25.1 source fix and #25.3 config fix need no adapter change — the adapter renders `mlsbench_src` and `config.json` straight from `src/`+`tasks/`, so they propagate automatically once #28's source edits are on the public source.)