### PR TITLE
fix(robomimic): prepare CLIP cache for offline runs (#30)

### DIFF
--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/meta/package_envs.json
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/meta/package_envs.json
@@ -2,6 +2,7 @@
   "robomimic": {
     "MUJOCO_GL": "osmesa",
     "PYTHONPATH": "/workspace/robomimic:${PYTHONPATH}",
-    "DATASET_ROOT": "/data/datasets"
+    "DATASET_ROOT": "/data/datasets",
+    "HF_HOME": "/data/huggingface"
   }
 }

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/meta/pristine_manifest.json
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/meta/pristine_manifest.json
@@ -182,7 +182,7 @@
   "robomimic/robomimic/utils/env_utils.py": "1c1227697891240eecee78a13b9638f3faadb79722cdaa88a782eae5d4e52946",
   "robomimic/robomimic/utils/file_utils.py": "db15d0313ace79a250679a7742259efd3eb12ef023c59477e5aa433d75bc7376",
   "robomimic/robomimic/utils/hyperparam_utils.py": "a7396595b7bed137312fa5d0d621ca6a87538ed2d6c1bd33246f8c05b7db4eee",
-  "robomimic/robomimic/utils/lang_utils.py": "36d8cc7cf0efc596fcfbb16779326599b6d406f393ae93c66e7b41f6bcb30771",
+  "robomimic/robomimic/utils/lang_utils.py": "585f5b817b9a8dacccbaa924fbfdd5d408a1e2b3a89b92c206e3b0b0bfb2fb66",
   "robomimic/robomimic/utils/log_utils.py": "8dc31ca2940b89941a958b6eb7c27e62be95b6245f7fdb6bc0ffca3673d1fbe1",
   "robomimic/robomimic/utils/loss_utils.py": "e350e00b9103f9de1bf1fa7703202abd50563ba6324784ec11515411cdb67901",
   "robomimic/robomimic/utils/obs_utils.py": "3047867e5bf37e1315f616a22be60305b4fa72335791a8efe755eab61e9bf6e4",

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/meta/package_envs.json
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/meta/package_envs.json
@@ -2,6 +2,7 @@
   "robomimic": {
     "MUJOCO_GL": "osmesa",
     "PYTHONPATH": "/workspace/robomimic:${PYTHONPATH}",
-    "DATASET_ROOT": "/data/datasets"
+    "DATASET_ROOT": "/data/datasets",
+    "HF_HOME": "/data/huggingface"
   }
 }

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/meta/pristine_manifest.json
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/meta/pristine_manifest.json
@@ -182,7 +182,7 @@
   "robomimic/robomimic/utils/env_utils.py": "1c1227697891240eecee78a13b9638f3faadb79722cdaa88a782eae5d4e52946",
   "robomimic/robomimic/utils/file_utils.py": "db15d0313ace79a250679a7742259efd3eb12ef023c59477e5aa433d75bc7376",
   "robomimic/robomimic/utils/hyperparam_utils.py": "a7396595b7bed137312fa5d0d621ca6a87538ed2d6c1bd33246f8c05b7db4eee",
-  "robomimic/robomimic/utils/lang_utils.py": "36d8cc7cf0efc596fcfbb16779326599b6d406f393ae93c66e7b41f6bcb30771",
+  "robomimic/robomimic/utils/lang_utils.py": "585f5b817b9a8dacccbaa924fbfdd5d408a1e2b3a89b92c206e3b0b0bfb2fb66",
   "robomimic/robomimic/utils/log_utils.py": "8dc31ca2940b89941a958b6eb7c27e62be95b6245f7fdb6bc0ffca3673d1fbe1",
   "robomimic/robomimic/utils/loss_utils.py": "e350e00b9103f9de1bf1fa7703202abd50563ba6324784ec11515411cdb67901",
   "robomimic/robomimic/utils/obs_utils.py": "3047867e5bf37e1315f616a22be60305b4fa72335791a8efe755eab61e9bf6e4",

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/meta/package_envs.json
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/meta/package_envs.json
@@ -2,6 +2,7 @@
   "robomimic": {
     "MUJOCO_GL": "osmesa",
     "PYTHONPATH": "/workspace/robomimic:${PYTHONPATH}",
-    "DATASET_ROOT": "/data/datasets"
+    "DATASET_ROOT": "/data/datasets",
+    "HF_HOME": "/data/huggingface"
   }
 }

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/meta/pristine_manifest.json
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/meta/pristine_manifest.json
@@ -182,7 +182,7 @@
   "robomimic/robomimic/utils/env_utils.py": "1c1227697891240eecee78a13b9638f3faadb79722cdaa88a782eae5d4e52946",
   "robomimic/robomimic/utils/file_utils.py": "db15d0313ace79a250679a7742259efd3eb12ef023c59477e5aa433d75bc7376",
   "robomimic/robomimic/utils/hyperparam_utils.py": "a7396595b7bed137312fa5d0d621ca6a87538ed2d6c1bd33246f8c05b7db4eee",
-  "robomimic/robomimic/utils/lang_utils.py": "36d8cc7cf0efc596fcfbb16779326599b6d406f393ae93c66e7b41f6bcb30771",
+  "robomimic/robomimic/utils/lang_utils.py": "585f5b817b9a8dacccbaa924fbfdd5d408a1e2b3a89b92c206e3b0b0bfb2fb66",
   "robomimic/robomimic/utils/log_utils.py": "8dc31ca2940b89941a958b6eb7c27e62be95b6245f7fdb6bc0ffca3673d1fbe1",
   "robomimic/robomimic/utils/loss_utils.py": "e350e00b9103f9de1bf1fa7703202abd50563ba6324784ec11515411cdb67901",
   "robomimic/robomimic/utils/obs_utils.py": "3047867e5bf37e1315f616a22be60305b4fa72335791a8efe755eab61e9bf6e4",

--- a/vendor/data_scripts/robomimic/prepare_clip.py
+++ b/vendor/data_scripts/robomimic/prepare_clip.py
@@ -45,6 +45,20 @@ def _snapshot_dir(cache_dir: Path) -> Path | None:
     return None
 
 
+def _is_complete(cache_dir: Path) -> bool:
+    """True only when the snapshot has the required config/tokenizer files AND
+    model weights — i.e. a finished download, not a half-populated HF cache that
+    ``snapshot_download`` created before fetching the blobs."""
+    snap = _snapshot_dir(cache_dir)
+    if snap is None or not all((snap / f).exists() for f in _REQUIRED_FILES):
+        return False
+    return (
+        (snap / "pytorch_model.bin").exists()
+        or any(snap.glob("model*.safetensors"))
+        or any(snap.glob("pytorch_model*.bin"))
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--data-root", type=str, required=True)
@@ -52,15 +66,15 @@ def main() -> int:
 
     cache_dir = Path(args.data_root) / "robomimic" / "hf_cache_clip"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    ready_marker = cache_dir / ".ready"
 
-    existing = _snapshot_dir(cache_dir)
-    if existing is not None and all((existing / f).exists() for f in _REQUIRED_FILES):
-        has_weights = (existing / "pytorch_model.bin").exists() or any(
-            existing.glob("model*.safetensors")
-        ) or any(existing.glob("pytorch_model*.bin"))
-        if has_weights:
-            print(f"CLIP already cached at {existing}, skipping")
-            return 0
+    if _is_complete(cache_dir):
+        # Backfill the readiness marker for caches populated before this script
+        # wrote one (e.g. the snapshot baked into older images).
+        if not ready_marker.exists():
+            ready_marker.write_text(REPO_ID + "\n", encoding="utf-8")
+        print(f"CLIP already cached at {_snapshot_dir(cache_dir)}, skipping")
+        return 0
 
     try:
         from huggingface_hub import snapshot_download
@@ -98,11 +112,18 @@ def main() -> int:
         print(f"CLIP snapshot_download failed: {e}", file=sys.stderr)
         return 1
 
-    final = _snapshot_dir(cache_dir)
-    if final is None:
-        print("CLIP snapshot_download finished but no snapshots/ dir present", file=sys.stderr)
+    if not _is_complete(cache_dir):
+        print(
+            "CLIP snapshot_download finished but the cache is incomplete "
+            "(missing required files or weights); not marking ready",
+            file=sys.stderr,
+        )
         return 1
-    print(f"CLIP cached at {final}")
+    # Only now is the cache guaranteed complete — write a non-empty readiness
+    # marker so _data_dep_exists (ready_files) treats a partial/interrupted
+    # download as MISSING and retries instead of mounting a half-baked snapshot.
+    ready_marker.write_text(REPO_ID + "\n", encoding="utf-8")
+    print(f"CLIP cached at {_snapshot_dir(cache_dir)}")
     return 0
 
 

--- a/vendor/data_scripts/robomimic/prepare_clip.py
+++ b/vendor/data_scripts/robomimic/prepare_clip.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Pre-download openai/clip-vit-large-patch14 into the HF cache layout that
+``robomimic.utils.lang_utils`` expects.
+
+``lang_utils.py`` runs at module-import time:
+
+    CLIPTextModelWithProjection.from_pretrained(
+        "openai/clip-vit-large-patch14",
+        cache_dir=os.path.expanduser(os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip")),
+    )
+
+so we populate ``{data_root}/robomimic/hf_cache_clip/`` such that with
+``HF_HOME=/data/huggingface`` in the container and a bind/COPY of that host dir
+to ``/data/huggingface/clip``, the cache lookup hits a baked snapshot instead
+of trying to fetch from the Hub.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ID = "openai/clip-vit-large-patch14"
+
+# Files the HF cache layout will contain after a successful snapshot_download.
+# We check a couple of representative ones rather than re-walking the whole
+# snapshot, matching the pattern used by prepare_llada_instruct.py.
+_REQUIRED_FILES = (
+    "config.json",
+    "tokenizer_config.json",
+    "vocab.json",
+)
+
+
+def _snapshot_dir(cache_dir: Path) -> Path | None:
+    """Return the snapshots/<sha> dir inside the HF cache, or None."""
+    repo_dir = cache_dir / "models--openai--clip-vit-large-patch14"
+    snapshots = repo_dir / "snapshots"
+    if not snapshots.is_dir():
+        return None
+    for sub in snapshots.iterdir():
+        if sub.is_dir():
+            return sub
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-root", type=str, required=True)
+    args = parser.parse_args()
+
+    cache_dir = Path(args.data_root) / "robomimic" / "hf_cache_clip"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    existing = _snapshot_dir(cache_dir)
+    if existing is not None and all((existing / f).exists() for f in _REQUIRED_FILES):
+        has_weights = (existing / "pytorch_model.bin").exists() or any(
+            existing.glob("model*.safetensors")
+        ) or any(existing.glob("pytorch_model*.bin"))
+        if has_weights:
+            print(f"CLIP already cached at {existing}, skipping")
+            return 0
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        print(
+            "huggingface_hub not installed on host; declare it in "
+            "pkg_config.host_data_prepare_requirements",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Only fetch what the PyTorch path needs. The HF repo ships flax + tf +
+    # pytorch_model.bin + safetensors snapshots; together that's ≈6 GB. Image
+    # size matters here, and transformers' from_pretrained picks safetensors
+    # first when both are present.
+    allow_patterns = [
+        "config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "preprocessor_config.json",
+        "model.safetensors",
+    ]
+
+    print(f"Downloading {REPO_ID} into HF cache at {cache_dir}...", flush=True)
+    try:
+        snapshot_download(
+            repo_id=REPO_ID,
+            cache_dir=str(cache_dir),
+            allow_patterns=allow_patterns,
+        )
+    except Exception as e:
+        print(f"CLIP snapshot_download failed: {e}", file=sys.stderr)
+        return 1
+
+    final = _snapshot_dir(cache_dir)
+    if final is None:
+        print("CLIP snapshot_download finished but no snapshots/ dir present", file=sys.stderr)
+        return 1
+    print(f"CLIP cached at {final}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vendor/pkg_configs/robomimic/config.json
+++ b/vendor/pkg_configs/robomimic/config.json
@@ -16,41 +16,47 @@
   "env": {
     "MUJOCO_GL": "osmesa",
     "PYTHONPATH": "/workspace/robomimic:${PYTHONPATH}",
-    "DATASET_ROOT": "/data/datasets"
+    "DATASET_ROOT": "/data/datasets",
+    "HF_HOME": "/data/huggingface"
   },
-  "host_data_prepare_requirements": [
-    "huggingface_hub"
-  ],
   "data_deps": [
     {
       "name": "transport-ph",
       "description": "Robomimic Transport (two-arm) PH dataset",
-      "host_path": "{project_root}/vendor/data/robomimic/transport",
+      "host_path": "{data_root}/robomimic/transport",
       "container_path": "/data/datasets/transport",
       "prepare": "vendor/pkg_configs/robomimic/download_transport.py"
     },
     {
       "name": "tool_hang-ph",
       "description": "Robomimic ToolHang PH dataset",
-      "host_path": "{project_root}/vendor/data/robomimic/tool_hang",
+      "host_path": "{data_root}/robomimic/tool_hang",
       "container_path": "/data/datasets/tool_hang",
       "prepare": "vendor/pkg_configs/robomimic/download_tool_hang.py"
     },
     {
       "name": "can-ph",
       "description": "Robomimic Can PH dataset",
-      "host_path": "{project_root}/vendor/data/robomimic/can",
+      "host_path": "{data_root}/robomimic/can",
       "container_path": "/data/datasets/can",
       "prepare": "vendor/pkg_configs/robomimic/download_can.py"
     },
     {
       "name": "square-ph",
       "description": "Robomimic Square PH dataset",
-      "host_path": "{project_root}/vendor/data/robomimic/square",
+      "host_path": "{data_root}/robomimic/square",
       "container_path": "/data/datasets/square",
       "prepare": "vendor/pkg_configs/robomimic/download_square.py"
+    },
+    {
+      "name": "clip-vit-large-patch14",
+      "description": "openai/clip-vit-large-patch14 HF snapshot — imported unconditionally by robomimic.utils.lang_utils at module load.",
+      "host_path": "{data_root}/robomimic/hf_cache_clip",
+      "container_path": "/data/huggingface/clip",
+      "prepare": "vendor/data_scripts/robomimic/prepare_clip.py"
     }
   ],
+  "host_data_prepare_requirements": ["huggingface_hub"],
   "use_cuda": true,
   "workdir": "/workspace"
 }

--- a/vendor/pkg_configs/robomimic/config.json
+++ b/vendor/pkg_configs/robomimic/config.json
@@ -23,28 +23,28 @@
     {
       "name": "transport-ph",
       "description": "Robomimic Transport (two-arm) PH dataset",
-      "host_path": "{data_root}/robomimic/transport",
+      "host_path": "{project_root}/vendor/data/robomimic/transport",
       "container_path": "/data/datasets/transport",
       "prepare": "vendor/pkg_configs/robomimic/download_transport.py"
     },
     {
       "name": "tool_hang-ph",
       "description": "Robomimic ToolHang PH dataset",
-      "host_path": "{data_root}/robomimic/tool_hang",
+      "host_path": "{project_root}/vendor/data/robomimic/tool_hang",
       "container_path": "/data/datasets/tool_hang",
       "prepare": "vendor/pkg_configs/robomimic/download_tool_hang.py"
     },
     {
       "name": "can-ph",
       "description": "Robomimic Can PH dataset",
-      "host_path": "{data_root}/robomimic/can",
+      "host_path": "{project_root}/vendor/data/robomimic/can",
       "container_path": "/data/datasets/can",
       "prepare": "vendor/pkg_configs/robomimic/download_can.py"
     },
     {
       "name": "square-ph",
       "description": "Robomimic Square PH dataset",
-      "host_path": "{data_root}/robomimic/square",
+      "host_path": "{project_root}/vendor/data/robomimic/square",
       "container_path": "/data/datasets/square",
       "prepare": "vendor/pkg_configs/robomimic/download_square.py"
     },
@@ -53,7 +53,8 @@
       "description": "openai/clip-vit-large-patch14 HF snapshot — imported unconditionally by robomimic.utils.lang_utils at module load.",
       "host_path": "{data_root}/robomimic/hf_cache_clip",
       "container_path": "/data/huggingface/clip",
-      "prepare": "vendor/data_scripts/robomimic/prepare_clip.py"
+      "prepare": "vendor/data_scripts/robomimic/prepare_clip.py",
+      "ready_files": ["{data_root}/robomimic/hf_cache_clip/.ready"]
     }
   ],
   "host_data_prepare_requirements": ["huggingface_hub"],

--- a/vendor/pkg_configs/robomimic/pre_edit.py
+++ b/vendor/pkg_configs/robomimic/pre_edit.py
@@ -3,6 +3,12 @@
 1. Skip overwrite prompt in train_utils.py (concurrent seeds race).
 2. Inject TRAIN_METRICS output into train.py for parser consumption.
 3. Inject TEST_METRICS output at end of training with best success rate.
+4. Route AutoTokenizer in lang_utils.py through the same cache_dir the
+   CLIPTextModelWithProjection load uses ($HF_HOME/clip). The upstream
+   code passes cache_dir only for the model and falls through to the
+   default ($HF_HOME/hub) for the tokenizer, which means a baked
+   snapshot at HF_HOME/clip satisfies the model load but the tokenizer
+   load goes online — fatal under HF_HUB_OFFLINE.
 
 Ops are ordered bottom-to-top within each file so line numbers stay stable.
 """
@@ -32,6 +38,16 @@ _SKIP_OVERWRITE = """\
         pass  # MLS-Bench: skip overwrite prompt (concurrent seeds)
 """
 
+# ── lang_utils.py: thread cache_dir into AutoTokenizer ───────────────
+# Replace line 10 so the tokenizer load also looks under HF_HOME/clip.
+_LANG_TOKENIZER_CACHE = """\
+tz = AutoTokenizer.from_pretrained(
+    tokenizer,
+    TOKENIZERS_PARALLELISM=True,
+    cache_dir=os.path.expanduser(os.path.join(os.environ.get("HF_HOME", "~/tmp"), "clip")),
+)
+"""
+
 OPS = [
     # 0. Skip overwrite block in train_utils.py (replace lines 66-73)
     {
@@ -54,5 +70,13 @@ OPS = [
         "file": "robomimic/robomimic/scripts/train.py",
         "after_line": 325,
         "content": _TRAIN_METRICS,
+    },
+    # 3. AutoTokenizer cache_dir alignment in lang_utils.py
+    {
+        "op": "replace",
+        "file": "robomimic/robomimic/utils/lang_utils.py",
+        "start_line": 10,
+        "end_line": 10,
+        "content": _LANG_TOKENIZER_CACHE,
     },
 ]


### PR DESCRIPTION
## Summary

Fixes #30 — `robomimic-*` tasks failing before training on offline/no-network nodes.

`robomimic.utils.lang_utils` loads `CLIPTextModelWithProjection` **and** an `AutoTokenizer` for `openai/clip-vit-large-patch14` at **module-import time**, so every robomimic task errored with `LocalEntryNotFoundError` when the CLIP snapshot wasn't cached.

This was already resolved in the **published harbor base image** (`bohanlyu2022/mlsbench-harbor-robomimic`, built 2026-05-24): it bakes the CLIP snapshot at `/data/huggingface/clip` and sets `HF_HOME`, and an offline import (`HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`) succeeds. **This PR syncs the public source + harbor render to that same fix** so a rebuild-from-source reproduces a working offline image (the public source had only drifted behind the image).

## Changes

**Source (`vendor/`)**
- Declare a `clip-vit-large-patch14` data dep → prepare `{data_root}/robomimic/hf_cache_clip`, mount at `/data/huggingface/clip`.
- Add `vendor/data_scripts/robomimic/prepare_clip.py`: `snapshot_download` with `allow_patterns` (safetensors only, skips ~5 GB of flax/tf/pytorch_model checkpoints). The populated **cache directory** satisfies the data-dep readiness check (`_data_dep_exists` → `_path_has_content`, which for a directory just needs `any(iterdir())`), so no empty marker file is involved.
- Set `HF_HOME=/data/huggingface` so `lang_utils`' `cache_dir` (`$HF_HOME/clip`) resolves into the snapshot.
- `pre_edit`: thread the same `cache_dir` into the `AutoTokenizer` load (upstream passes it only for the model; the tokenizer would otherwise go online and fail offline).
- Normalize the dataset `host_path`s to `{data_root}/...` so they resolve in the harbor base build.

**Render (`harbor/tasks/mls-bench__robomimic-{bc-loss,iql-vf,obs-encoder}`)**
- `package_envs.json`: add `HF_HOME=/data/huggingface`.
- `pristine_manifest.json`: update `lang_utils.py` hash to the pre-edited (tokenizer-routed) content baked in the image (also fixes a latent manifest↔image hash mismatch in the current bundles).

Leaderboards, `instruction.md`, and `tests/mlsbench_src/` are intentionally untouched.