### PR TITLE
fix(dbim-codebase): headless OpenCV for host data prepare (#31)

### DIFF
--- a/vendor/pkg_configs/dbim-codebase/config.json
+++ b/vendor/pkg_configs/dbim-codebase/config.json
@@ -2,7 +2,7 @@
   "base_image": "pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime",
   "host_data_prepare_requirements": [
     "huggingface_hub>=0.20",
-    "opencv-python",
+    "opencv-python-headless",
     "matplotlib",
     "numpy",
     "torch",


### PR DESCRIPTION
## Summary

Fixes #31 — `dbim-codebase` / `cv-dbm-sampler` host data preparation crashes during DIODE preprocessing.

`vendor/data_scripts/dbim-codebase/prepare_data.py` does `import cv2` (for `cv2.resize`) in the host data-prepare environment. The GUI `opencv-python` wheel requires X11 system libraries such as `libxcb.so.1`, which aren't present there, so prepare fails with:

```
ImportError: libxcb.so.1: cannot open shared object file: No such file or directory
```

## Fix

Switch **only** `host_data_prepare_requirements` to `opencv-python-headless` (same `cv2` API, no GUI/X11 deps). The runtime container `install_cmds` keep `opencv-python` — this issue is specifically about host-side data prep, per the report.

Thanks to @rabhub for the precise diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)