### PR TITLE
fix(harbor/ts): budget_check compares agent vs baselines at matched capacity (fixes all-agent 0 on TSLib tasks)

### DIFF
--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/meta/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/harbor/tasks/mls-bench__ts-classification/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/meta/budget_check.py
@@ -199,6 +199,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -214,17 +215,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/meta/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/harbor/tasks/mls-bench__ts-imputation/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/meta/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/meta/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/meta/budget_check.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/meta/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-anomaly-detection/budget_check.py
+++ b/tasks/ts-anomaly-detection/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-classification/budget_check.py
+++ b/tasks/ts-classification/budget_check.py
@@ -199,6 +199,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -214,17 +215,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-exogenous-forecast/budget_check.py
+++ b/tasks/ts-exogenous-forecast/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-imputation/budget_check.py
+++ b/tasks/ts-imputation/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-long-term-forecast/budget_check.py
+++ b/tasks/ts-long-term-forecast/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:

--- a/tasks/ts-short-term-forecast/budget_check.py
+++ b/tasks/ts-short-term-forecast/budget_check.py
@@ -195,6 +195,7 @@ test_entry = active_test_cmd(config)
 agent_args = prepare_runtime_args(parse_run_args(expand_script_argv(TASK_DIR / test_entry["cmd"])))
 
 baseline_params = {}
+forced_baseline_params = {}
 for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     script_path = TASK_DIR / baseline_cfg["cmd"]
     script_args = prepare_runtime_args(parse_run_args(expand_script_argv(script_path)))
@@ -210,17 +211,61 @@ for baseline_name, baseline_cfg in config.get("baselines", {}).items():
     baseline_params[baseline_name] = params
     print(f"  baseline {baseline_name}: {params} params")
 
+    # Same-spec (matched-capacity) count: rebuild this baseline at the agent's
+    # FORCED config -- i.e. the read-only eval script's (d_model, d_ff,
+    # e_layers), carried on agent_args -- so the budget compares agent and
+    # baselines like-for-like. The per-dataset baseline configs are often
+    # *smaller* than the size the agent is forced to use (e.g. TimeXer uses
+    # d_model=128 on Weather), which is exactly what makes a plain "1.05 x
+    # largest *native* baseline" budget collapse below any honest d_model=512
+    # model and zero out every agent. TimesNet is skipped here on purpose: it is
+    # conv/FFT-based and balloons to ~3e8 params at d_model=512 (TSLib itself
+    # runs it at d_model<=64), so it is not a fair same-spec reference -- its
+    # properly tuned size still counts via the native term above.
+    if script_args.model != "TimesNet":
+        try:
+            forced = count_params(module_path, agent_args)
+            forced_baseline_params[baseline_name] = forced
+            print(f"  baseline {baseline_name} @ agent config: {forced} params")
+        except Exception as exc:
+            print(f"  baseline {baseline_name} @ agent config: ERROR ({exc})")
+
 if not baseline_params:
     print("WARNING: no baselines could be evaluated, skipping budget check")
     sys.exit(0)
 
 max_baseline_name = max(baseline_params, key=baseline_params.get)
 max_baseline_params = baseline_params[max_baseline_name]
-budget = int(max_baseline_params * 1.05)
+
+# Budget basis: 1.05 x the strongest baseline, compared at a *matched* capacity.
+#
+# The agent's eval scripts hardcode (d_model, d_ff, e_layers) and the agent
+# cannot change them (the scripts are read-only). On several datasets the
+# per-dataset-tuned baselines are configured *smaller* than that forced size,
+# so a plain "1.05 x largest *native* baseline" budget can fall below any honest
+# model built at the forced d_model -- making the budget unsatisfiable and
+# collapsing every agent's score to 0 (one failed setting zeroes the gmean)
+# through no fault of the agent.
+#
+# Fix: also consider each baseline rebuilt at the agent's forced config
+# (forced_baseline_params, gathered in the loop above) and take the larger
+# basis. This is a like-for-like, same-spec comparison -- the agent is held to
+# 1.05x the strongest baseline *at the same capacity it is forced to use*. It
+# only ever raises the budget (max with the native value), so no previously
+# passing run can newly fail.
+budget_basis_name = max_baseline_name
+budget_basis_params = max_baseline_params
+if forced_baseline_params:
+    forced_max_name = max(forced_baseline_params, key=forced_baseline_params.get)
+    forced_max_params = forced_baseline_params[forced_max_name]
+    if forced_max_params > budget_basis_params:
+        budget_basis_name = f"{forced_max_name}@agent_cfg"
+        budget_basis_params = forced_max_params
+budget = int(budget_basis_params * 1.05)
 
 agent_params = count_params(WORKSPACE_FILE, agent_args)
 print(f"\n  agent model: {agent_params} params")
-print(f"  budget: {budget} (1.05 x {max_baseline_name}={max_baseline_params})")
+print(f"  budget: {budget} (1.05 x {budget_basis_name}={budget_basis_params})")
 print(f"  env={os.environ.get('ENV', '')}, task={agent_args.task_name}, model_id={agent_args.model_id}")
 
 if agent_params > budget:


### PR DESCRIPTION
## Problem: all agents score 0 on the Time-Series-Library tasks

On 5 of the 6 TSLib tasks, **every** agent (opus-4.8, gpt-5.5, opus-4.7, …) scored `combined_score = 0` regardless of how good its submission was — a budget-check config bug, not an agent problem.

**Root cause.** The agent can edit only `models/Custom.py`, while the eval scripts hardcode `--d_model 512 --d_ff 512 --e_layers 2` (read-only). So an honest agent model is ~3.2M–6.9M params on every dataset. But `tests/meta/budget_check.py` set the budget to `1.05 × the largest *native* baseline`, and the per-dataset baseline configs are often tuned much smaller (e.g. TimeXer uses `d_model=128` on Weather; the imputation/anomaly settings tune TimesNet/PatchTST to `d_model≤128`). On those settings the budget fell **below any honest `d_model=512` model**, so the agent failed `budget_check` (rc=1) on ≥1 setting → that setting scored 0 → the per-setting **gmean** collapsed the whole `combined_score` to 0.

**Verified-broken (task, setting) pairs** (real param counts): exogenous `Weather`/`ECL`, long-term `ETTh1`, imputation `ETTh1`, anomaly `MSL`, short-term `m4_monthly`/`m4_yearly`. `ts-classification` was the only well-formed one — it already forces the agent to the **same** `d_model=128/d_ff=256/e_layers=3` as its baselines.

## Fix: compare the agent against baselines at matched capacity

Budget = `1.05 × max(strongest native baseline, strongest baseline rebuilt at the agent's forced d_model)`. This is a like-for-like, same-spec comparison: the agent is held to 1.05× the strongest baseline *at the capacity it is forced to use*.

- **TimesNet is excluded from the forced-config term only** — it is conv/FFT-based and balloons to ~3×10⁸ params at `d_model=512` (which is exactly why TSLib runs it at `d_model≤64`); its properly-tuned size still counts via the native term.
- The change only ever **raises** the budget (`max` with the native value), so no previously-passing run can newly fail.

## Scope / relation to prior work

This complements the earlier **oracle-side** fix (`score_task.py` honoring the baseline cmd override, public `4aae28e`): that fixed the *oracle* being measured at the wrong hyperparameters; this fixes the *agent* being held to an unsatisfiable budget. Both run paths exec `tests/meta/budget_check.py`, so this covers native MLSBench and Harbor. The other ~48 `budget_check.py` tasks were audited and are unaffected (they build agent + baselines at the same fixed config; `pde-design-solver` is the safe direction, ~4× headroom).

Synced verbatim from dev `tasks/ts-*/budget_check.py` (the adapter copies `budget_check.py` verbatim, so this matches what a re-render would emit — no full re-render, no `instruction.md`/leaderboard disturbance).

## Testing

Ran the patched `budget_check.py` for all 18 (task, setting) pairs:
- Lean standard arch (iTransformer ~3.2M) **PASSES everywhere** → no more guaranteed-0.
- ~49M bloat model **FAILS everywhere** → budget still a meaningful cap.
- The reported exogenous TimeXer-scale agent (~5.66M) now **PASSES** ETTh1/Weather/ECL.

Dev commit: `59bcb52ca` (branch `fix/tslib-budget-same-spec`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
