### PR TITLE
fix(stabletoolbench): wire server_data prepare script into data_deps

### DIFF
--- a/vendor/data_scripts/stabletoolbench/prepare_data.py
+++ b/vendor/data_scripts/stabletoolbench/prepare_data.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Prepare server_data for stabletoolbench.
+
+Downloads the ``stabletoolbench/Cache`` HF dataset and extracts
+``server_cache.zip`` into the host data path that the runtime data_bind
+mounts into the container. This must run on the host: the pkg_config
+install_cmds run inside the image build, where the literal ``{data_root}``
+template is NOT expanded by the apptainer or docker build path and the
+host data dir is not writable, so an install-time download never lands
+on the host.
+
+This script is wired into ``vendor/pkg_configs/stabletoolbench/config.json``
+as a ``data_deps`` entry, so ``mlsbench data stabletoolbench`` /
+``mlsbench build`` / the agent auto-pipeline invoke it automatically. It
+is idempotent (skips the download when ``server_data/tools`` is already
+populated).
+
+Run manually via:
+    python vendor/data_scripts/stabletoolbench/prepare_data.py \\
+        --data-root <data_root>
+
+Output:
+    <data_root>/stabletoolbench/server_data/tools/...
+    <data_root>/stabletoolbench/server_data/answer/...
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+
+def _ensure_huggingface_hub() -> None:
+    try:
+        import huggingface_hub  # noqa: F401
+    except ImportError:
+        import subprocess
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--no-cache-dir",
+             "huggingface_hub"]
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-root", required=True)
+    args = ap.parse_args()
+
+    root = Path(args.data_root) / "stabletoolbench" / "server_data"
+    if root.exists() and any(root.iterdir()):
+        # Cheap check: if `tools/` is present, treat as ready.
+        tools = root / "tools"
+        if tools.exists() and any(tools.iterdir()):
+            print(f"[stabletoolbench] server_data already populated at {root}")
+            return 0
+
+    _ensure_huggingface_hub()
+    from huggingface_hub import snapshot_download
+
+    root.mkdir(parents=True, exist_ok=True)
+    download_dir = root.parent / "cache_download"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[stabletoolbench] snapshot_download stabletoolbench/Cache -> {download_dir}",
+          flush=True)
+    snapshot_download(
+        "stabletoolbench/Cache",
+        repo_type="dataset",
+        local_dir=str(download_dir),
+    )
+    server_zip = download_dir / "server_cache.zip"
+    if not server_zip.exists():
+        # Some snapshots ship the zip elsewhere; search.
+        for candidate in download_dir.rglob("server_cache.zip"):
+            server_zip = candidate
+            break
+    if not server_zip.exists():
+        print(f"[stabletoolbench] ERROR: server_cache.zip not found in {download_dir}",
+              file=sys.stderr)
+        return 1
+    print(f"[stabletoolbench] extracting {server_zip} -> {root}", flush=True)
+    with zipfile.ZipFile(str(server_zip)) as zf:
+        zf.extractall(str(root))
+    print("[stabletoolbench] server_data ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vendor/pkg_configs/stabletoolbench/config.json
+++ b/vendor/pkg_configs/stabletoolbench/config.json
@@ -3,8 +3,16 @@
   "install_cmds": [
     "pip install torch --index-url https://download.pytorch.org/whl/cpu",
     "pip install openai httpx tenacity termcolor fastapi uvicorn requests tqdm pyyaml pyarrow slowapi 'huggingface_hub[cli]' psutil transformers accelerate sentencepiece",
-    "cd server && pip install -r requirements.txt && cd ..",
-    "mkdir -p {data_root}/stabletoolbench/server_data && if [ ! -d {data_root}/stabletoolbench/server_data/tools ]; then cd server && python -c \"from huggingface_hub import snapshot_download; snapshot_download('stabletoolbench/Cache', repo_type='dataset', local_dir='cache_download')\" && python -c \"import zipfile; zipfile.ZipFile('cache_download/server_cache.zip').extractall('{data_root}/stabletoolbench/server_data')\" && cd ..; fi"
+    "cd server && pip install -r requirements.txt && cd .."
+  ],
+  "data_deps": [
+    {
+      "name": "stabletoolbench-server-data",
+      "host_path": "{data_root}/stabletoolbench/server_data",
+      "container_path": "/data/stabletoolbench/server_data",
+      "prepare": "vendor/data_scripts/stabletoolbench/prepare_data.py",
+      "description": "StableToolBench server_data cache (tools/ + answer/) extracted from the HF dataset stabletoolbench/Cache; bound into the container at /data/stabletoolbench/server_data (TOOL_SERVER_DATA_DIR). Prepared on the host because install_cmds run inside the build container, where {data_root} is not expanded and not host-writable."
+    }
   ],
   "data_bind": "{data_root}/stabletoolbench/server_data:/data/stabletoolbench/server_data",
   "env": {

--- a/vendor/pkg_configs/stabletoolbench/config.json
+++ b/vendor/pkg_configs/stabletoolbench/config.json
@@ -11,6 +11,7 @@
       "host_path": "{data_root}/stabletoolbench/server_data",
       "container_path": "/data/stabletoolbench/server_data",
       "prepare": "vendor/data_scripts/stabletoolbench/prepare_data.py",
+      "ready_files": ["{data_root}/stabletoolbench/server_data/tools"],
       "description": "StableToolBench server_data cache (tools/ + answer/) extracted from the HF dataset stabletoolbench/Cache; bound into the container at /data/stabletoolbench/server_data (TOOL_SERVER_DATA_DIR). Prepared on the host because install_cmds run inside the build container, where {data_root} is not expanded and not host-writable."
     }
   ],


### PR DESCRIPTION
## Summary

Ports dev #154 to public. The **agent-tool-reasoning** task depends on the `stabletoolbench` `server_data` cache (`tools/` + `answer/`, served via `TOOL_SERVER_DATA_DIR`), but the package had **no `data_deps` entry**, and the public repo was also **missing `vendor/data_scripts/stabletoolbench/prepare_data.py` entirely**.

- The prepare script was an orphan — nothing referenced it, so `mlsbench data` / `build` / the agent auto-pipeline never ran it (`cmd_data` only discovers packages whose `data_deps` is non-empty).
- The only populate mechanism was an `install_cmds` HF `snapshot_download` into `{data_root}/stabletoolbench/server_data`, but `{data_root}` isn't expanded in the docker/apptainer build path and `install_cmds` run inside the build container (host dir not writable) → it baked a useless copy at a literal path and never served runtime. Previously the cache had to be populated by hand.

## Fix

1. Add `vendor/data_scripts/stabletoolbench/prepare_data.py` (new in public).
2. Add a `data_deps` entry pointing `prepare` at it; `host_path`/`container_path` match the existing `data_bind`, so `resolve_data_binds` dedups to a single mount.
3. Drop the dead `install_cmds` download.

Host-prep/source only — no harbor render change (data_deps/host prep don't go into harbor bundles). Both files are byte-identical to dev `main` post-#154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)