### PR TITLE
docs(harbor): editable ranges are content-anchored regions, not a fixed line-count budget

### DIFF
--- a/harbor/tasks/mls-bench__agent-tool-reasoning/instruction.md
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/instruction.md
@@ -33,8 +33,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `stabletoolbench/toolbench/inference/Algorithms/custom_search.py`
 - editable lines **368–439**

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/instruction.md
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/instruction.md
@@ -51,8 +51,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ProteinGym/custom_mutation_pred.py`
 - editable lines **108–137**

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/instruction.md
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/instruction.md
@@ -61,8 +61,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ProteinInvBench/custom_invfold.py`
 - editable lines **86–238**

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/instruction.md
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/instruction.md
@@ -40,8 +40,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ProteinWorkshop/custom_protein_encoder.py`
 - editable lines **125–252**

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ClimSim/custom_emulator.py`
 - editable lines **86–118**

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/instruction.md
@@ -39,8 +39,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `InverseBench/algo/custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/instruction.md
@@ -76,8 +76,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Uni-Mol/custom_molprop.py`
 - editable lines **115–207**

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/instruction.md
@@ -79,8 +79,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `EHIGN_PLA/custom_pla.py`
 - editable lines **101–191**

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `HypSeek/unimol/custom_scoring.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/instruction.md
@@ -60,8 +60,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ClimaX/custom_forecast.py`
 - editable lines **310–351**

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/instruction.md
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/instruction.md
@@ -66,8 +66,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `causal-bnlearn/bench/custom_algorithm.py`
 - editable lines **3–14**

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/instruction.md
@@ -52,8 +52,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `causal-learn/bench/custom_algorithm.py`
 - editable lines **3–14**

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `causal-learn/bench/custom_algorithm.py`
 - editable lines **3–14**

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/instruction.md
@@ -55,8 +55,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `causal-learn/bench/custom_algorithm.py`
 - editable lines **3–14**

--- a/harbor/tasks/mls-bench__causal-treatment-effect/instruction.md
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/instruction.md
@@ -63,8 +63,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_cate.py`
 - editable lines **344–416**

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/instruction.md
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/instruction.md
@@ -120,8 +120,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `gsplat/custom_strategy.py`
 - editable lines **20–90**

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/instruction.md
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/instruction.md
@@ -107,8 +107,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `gsplat/custom_regularizer.py`
 - editable lines **37–51**

--- a/harbor/tasks/mls-bench__cv-classification-loss/instruction.md
+++ b/harbor/tasks/mls-bench__cv-classification-loss/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_loss.py`
 - editable lines **246–266**

--- a/harbor/tasks/mls-bench__cv-data-augmentation/instruction.md
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_augment.py`
 - editable lines **246–275**

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/instruction.md
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/instruction.md
@@ -109,8 +109,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `dbim-codebase/ddbm/karras_diffusion.py`
 - editable lines **459–470**

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/instruction.md
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/instruction.md
@@ -74,8 +74,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `dbim-codebase/ddbm/karras_diffusion.py`
 - editable lines **310–321**

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/instruction.md
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/instruction.md
@@ -72,8 +72,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `diffusers-main/custom_train.py`
 - editable lines **31–58**

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/instruction.md
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/instruction.md
@@ -74,8 +74,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CFGpp-main/latent_diffusion.py`
 - editable lines **622–680**

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/instruction.md
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/instruction.md
@@ -65,8 +65,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `diffusers-main/custom_train.py`
 - editable lines **195–227**

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/instruction.md
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/instruction.md
@@ -78,8 +78,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CFGpp-main/latent_diffusion.py`
 - editable lines **622–678**

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/instruction.md
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/instruction.md
@@ -70,8 +70,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `diffusers-main/custom_train.py`
 - editable lines **83–118**

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/instruction.md
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/instruction.md
@@ -78,8 +78,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `alphaflow-main/custom_train_perceptual.py`
 - editable lines **445–462**

--- a/harbor/tasks/mls-bench__cv-multitask-loss/instruction.md
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_mtl.py`
 - editable lines **195–216**

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/instruction.md
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_pool.py`
 - editable lines **31–48**

--- a/harbor/tasks/mls-bench__cv-sample-weighting/instruction.md
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_weighting.py`
 - editable lines **164–195**

--- a/harbor/tasks/mls-bench__cv-vae-loss/instruction.md
+++ b/harbor/tasks/mls-bench__cv-vae-loss/instruction.md
@@ -85,8 +85,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `diffusers-main/custom_train.py`
 - editable lines **32–76**

--- a/harbor/tasks/mls-bench__dl-activation-function/instruction.md
+++ b/harbor/tasks/mls-bench__dl-activation-function/instruction.md
@@ -42,8 +42,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_activation.py`
 - editable lines **32–49**

--- a/harbor/tasks/mls-bench__dl-lr-schedule/instruction.md
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/instruction.md
@@ -45,8 +45,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_schedule.py`
 - editable lines **246–269**

--- a/harbor/tasks/mls-bench__dl-normalization/instruction.md
+++ b/harbor/tasks/mls-bench__dl-normalization/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_norm.py`
 - editable lines **31–45**

--- a/harbor/tasks/mls-bench__dl-regularization/instruction.md
+++ b/harbor/tasks/mls-bench__dl-regularization/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_reg.py`
 - editable lines **246–273**

--- a/harbor/tasks/mls-bench__dl-residual-connection/instruction.md
+++ b/harbor/tasks/mls-bench__dl-residual-connection/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_residual.py`
 - editable lines **31–61**

--- a/harbor/tasks/mls-bench__dl-weight-initialization/instruction.md
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/instruction.md
@@ -42,8 +42,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_init.py`
 - editable lines **228–261**

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/instruction.md
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/instruction.md
@@ -99,8 +99,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `dLLM-cache/custom_dlm_eval.py`
 - editable lines **53–113**

--- a/harbor/tasks/mls-bench__graph-generation/instruction.md
+++ b/harbor/tasks/mls-bench__graph-generation/instruction.md
@@ -66,8 +66,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-geometric/custom_graphgen.py`
 - editable lines **446–590**

--- a/harbor/tasks/mls-bench__graph-graph-classification/instruction.md
+++ b/harbor/tasks/mls-bench__graph-graph-classification/instruction.md
@@ -74,8 +74,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-geometric/custom_graph_cls.py`
 - editable lines **41–81**

--- a/harbor/tasks/mls-bench__graph-link-prediction/instruction.md
+++ b/harbor/tasks/mls-bench__graph-link-prediction/instruction.md
@@ -79,8 +79,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-geometric-lp/custom_linkpred.py`
 - editable lines **127–210**

--- a/harbor/tasks/mls-bench__graph-node-classification/instruction.md
+++ b/harbor/tasks/mls-bench__graph-node-classification/instruction.md
@@ -76,8 +76,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-geometric/custom_nodecls.py`
 - editable lines **48–157**

--- a/harbor/tasks/mls-bench__graph-signal-propagation/instruction.md
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/instruction.md
@@ -78,8 +78,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `ChebNetII/main/custom_filter.py`
 - editable lines **211–308**

--- a/harbor/tasks/mls-bench__jepa-planning/instruction.md
+++ b/harbor/tasks/mls-bench__jepa-planning/instruction.md
@@ -59,8 +59,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `eb_jepa/custom_planner.py`
 - editable lines **323–367**

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/instruction.md
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `eb_jepa/custom_prediction_loss.py`
 - editable lines **36–54**

--- a/harbor/tasks/mls-bench__jepa-regularizer/instruction.md
+++ b/harbor/tasks/mls-bench__jepa-regularizer/instruction.md
@@ -30,8 +30,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `eb_jepa/custom_regularizer.py`
 - editable lines **33–58**

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/instruction.md
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/instruction.md
@@ -58,8 +58,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `LLaDA/custom_demask_eval.py`
 - editable lines **59–151**

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/instruction.md
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/instruction.md
@@ -112,8 +112,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `transformers-kv-lab/custom_quant_eval.py`
 - editable lines **41–172**

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/instruction.md
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/instruction.md
@@ -105,8 +105,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `transformers-kv-lab/custom_selection_eval.py`
 - editable lines **40–101**

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/instruction.md
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/instruction.md
@@ -78,8 +78,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **36–155**

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/instruction.md
@@ -37,8 +37,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **33–70**

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **38–115**

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/instruction.md
@@ -46,8 +46,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **115–140**

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/instruction.md
@@ -37,8 +37,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **33–48**

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **33–70**

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **188–191**

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/instruction.md
@@ -41,8 +41,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **191–201**

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **72–86**

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/instruction.md
@@ -39,8 +39,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **22–31**

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/instruction.md
@@ -45,8 +45,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **171–189**

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/instruction.md
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `nanoGPT/custom_pretrain.py`
 - editable lines **88–99**

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/instruction.md
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/instruction.md
@@ -121,8 +121,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `gptq/custom_ptq.py`
 - editable lines **26–157**

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/instruction.md
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/instruction.md
@@ -163,8 +163,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `llm-qat-runtime/custom_qat.py`
 - editable lines **33–176**

--- a/harbor/tasks/mls-bench__llm-rl-advantage/instruction.md
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/instruction.md
@@ -59,8 +59,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `verl/verl/trainer/ppo/custom_advantage.py`
 - editable lines **17–72**

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/instruction.md
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/instruction.md
@@ -72,8 +72,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `verl/verl/trainer/ppo/custom_policy_loss.py`
 - editable lines **17–72**

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/instruction.md
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `verl/verl/trainer/ppo/custom_kl_penalty.py`
 - editable lines **17–56**

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/instruction.md
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `verl/verl/trainer/ppo/custom_reward_normalization.py`
 - editable lines **17–72**

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/instruction.md
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/instruction.md
@@ -54,8 +54,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scaling-law-lab/custom_scaling_law.py`
 - editable lines **183–211**

--- a/harbor/tasks/mls-bench__marl-centralized-critic/instruction.md
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/instruction.md
@@ -72,8 +72,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `epymarl/src/modules/critics/custom_critic.py`
 - editable lines **7–8**

--- a/harbor/tasks/mls-bench__mas-topology/instruction.md
+++ b/harbor/tasks/mls-bench__mas-topology/instruction.md
@@ -51,8 +51,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `chatdev-macnet/custom_topology.py`
 - editable lines **16–42**

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/instruction.md
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/instruction.md
@@ -61,8 +61,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `easy-few-shot-learning/custom_fewshot.py`
 - editable lines **225–286**

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/instruction.md
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `learn2learn/custom_maml.py`
 - editable lines **177–254**

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/instruction.md
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/instruction.md
@@ -104,8 +104,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `oyster/custom_meta_rl.py`
 - editable lines **357–494**

--- a/harbor/tasks/mls-bench__meta-rl/instruction.md
+++ b/harbor/tasks/mls-bench__meta-rl/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `oyster/custom_encoder.py`
 - editable lines **21–23**

--- a/harbor/tasks/mls-bench__ml-active-learning/instruction.md
+++ b/harbor/tasks/mls-bench__ml-active-learning/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `badge/query_strategies/custom_sampling.py`
 - editable lines **28–54**

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/instruction.md
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/instruction.md
@@ -49,8 +49,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_anomaly.py`
 - editable lines **160–212**

--- a/harbor/tasks/mls-bench__ml-calibration/instruction.md
+++ b/harbor/tasks/mls-bench__ml-calibration/instruction.md
@@ -39,8 +39,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_calibration.py`
 - editable lines **45–102**

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/instruction.md
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/instruction.md
@@ -40,8 +40,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_clustering.py`
 - editable lines **36–109**

--- a/harbor/tasks/mls-bench__ml-continual-regularization/instruction.md
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `continual-learning/custom_regularization.py`
 - editable lines **25–115**

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/instruction.md
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/instruction.md
@@ -42,8 +42,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/bench/custom_dimred.py`
 - editable lines **15–59**

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/instruction.md
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/instruction.md
@@ -54,8 +54,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_boosting.py`
 - editable lines **147–256**

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/instruction.md
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `flower/custom_fl_aggregation.py`
 - editable lines **340–420**

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/instruction.md
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_imputation.py`
 - editable lines **36–131**

--- a/harbor/tasks/mls-bench__ml-selective-deferral/instruction.md
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/instruction.md
@@ -63,8 +63,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_selective.py`
 - editable lines **253–287**

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/instruction.md
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_subgroup_calibration.py`
 - editable lines **200–219**

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/instruction.md
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/instruction.md
@@ -54,8 +54,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `gplearn/custom_sr.py`
 - editable lines **228–306**

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/instruction.md
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/instruction.md
@@ -94,8 +94,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `flash-attention/custom_triton_bench.py`
 - editable lines **29–119**

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/instruction.md
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/instruction.md
@@ -101,8 +101,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `eplb/custom_eplb.py`
 - editable lines **62–209**

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/instruction.md
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/instruction.md
@@ -112,8 +112,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `sparse-attn-eval/custom_sparse_attn.py`
 - editable lines **31–103**

--- a/harbor/tasks/mls-bench__optimization-bilevel/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-bilevel/instruction.md
@@ -56,8 +56,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `penalized-bilevel-gradient-descent/mlsbench/custom_strategy.py`
 - editable lines **227–262**

--- a/harbor/tasks/mls-bench__optimization-convex-concave/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/instruction.md
@@ -45,8 +45,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `RAIN/optimization_convex_concave/custom_strategy.py`
 - editable lines **24–75**

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/instruction.md
@@ -64,8 +64,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `RAIN/opt_diagonal_net/custom_optimizer.py`
 - editable lines **23–90**

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/instruction.md
@@ -51,8 +51,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `opacus/custom_dpsgd.py`
 - editable lines **152–233**

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `deap/custom_evolution.py`
 - editable lines **87–225**

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/instruction.md
@@ -51,8 +51,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_compressor.py`
 - editable lines **182–232**

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/instruction.md
@@ -78,8 +78,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `scikit-learn/custom_hpo.py`
 - editable lines **255–326**

--- a/harbor/tasks/mls-bench__optimization-multi-objective/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/instruction.md
@@ -76,8 +76,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `deap/custom_moea.py`
 - editable lines **297–441**

--- a/harbor/tasks/mls-bench__optimization-nas/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-nas/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `naslib/custom_nas_search.py`
 - editable lines **163–234**

--- a/harbor/tasks/mls-bench__optimization-online-bandit/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/instruction.md
@@ -49,8 +49,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `SMPyBandits/custom_bandit.py`
 - editable lines **261–321**

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/instruction.md
@@ -54,8 +54,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `PBB/custom_pac_bayes.py`
 - editable lines **460–604**

--- a/harbor/tasks/mls-bench__optimization-parity/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-parity/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-examples/optimization_parity/custom_strategy.py`
 - editable lines **220–255**

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/instruction.md
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/instruction.md
@@ -62,8 +62,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `opt-vr-bench/custom_vr.py`
 - editable lines **286–370**

--- a/harbor/tasks/mls-bench__pde-design-solver/instruction.md
+++ b/harbor/tasks/mls-bench__pde-design-solver/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Neural-Solver-Library/models/Custom.py`
 - editable lines **1–64**

--- a/harbor/tasks/mls-bench__quant-concept-drift/instruction.md
+++ b/harbor/tasks/mls-bench__quant-concept-drift/instruction.md
@@ -40,8 +40,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `qlib/custom_model.py`
 - editable lines **16–103**

--- a/harbor/tasks/mls-bench__quant-graph-stock/instruction.md
+++ b/harbor/tasks/mls-bench__quant-graph-stock/instruction.md
@@ -40,8 +40,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `qlib/custom_model.py`
 - editable lines **58–156**

--- a/harbor/tasks/mls-bench__quant-stock-prediction/instruction.md
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `qlib/custom_model.py`
 - editable lines **16–103**

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/instruction.md
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/instruction.md
@@ -55,8 +55,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `cleanrl/cleanrl/custom_intrinsic_exploration.py`
 - editable lines **179–219**

--- a/harbor/tasks/mls-bench__rl-offline-adroit/instruction.md
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CORL/algorithms/offline/custom_adroit.py`
 - editable lines **214–416**

--- a/harbor/tasks/mls-bench__rl-offline-continuous/instruction.md
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CORL/algorithms/offline/custom.py`
 - editable lines **193–397**

--- a/harbor/tasks/mls-bench__rl-offline-off2on/instruction.md
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/instruction.md
@@ -56,8 +56,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CORL/algorithms/finetune/custom_finetune.py`
 - editable lines **258–477**

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/instruction.md
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `cleanrl/cleanrl/custom_offpolicy_continuous.py`
 - editable lines **153–244**

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/instruction.md
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `cleanrl/cleanrl/custom_onpolicy_continuous.py`
 - editable lines **175–221**

--- a/harbor/tasks/mls-bench__rl-reward-learning/instruction.md
+++ b/harbor/tasks/mls-bench__rl-reward-learning/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `imitation/custom_irl.py`
 - editable lines **231–357**

--- a/harbor/tasks/mls-bench__rl-value-atari/instruction.md
+++ b/harbor/tasks/mls-bench__rl-value-atari/instruction.md
@@ -44,8 +44,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `cleanrl/cleanrl/custom_value_atari.py`
 - editable lines **186–249**

--- a/harbor/tasks/mls-bench__rl-value-discrete/instruction.md
+++ b/harbor/tasks/mls-bench__rl-value-discrete/instruction.md
@@ -41,8 +41,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `cleanrl/cleanrl/custom_value_discrete.py`
 - editable lines **174–242**

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/instruction.md
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/instruction.md
@@ -74,8 +74,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CleanDiffuser/pipelines/custom_guidance.py`
 - editable lines **1–28**

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/instruction.md
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/instruction.md
@@ -49,8 +49,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CleanDiffuser/pipelines/custom_policy.py`
 - editable lines **1–20**

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/instruction.md
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/instruction.md
@@ -47,8 +47,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`
 - editable lines **15–15**

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/instruction.md
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/instruction.md
@@ -121,8 +121,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `humanoid-gym/humanoid/algo/ppo/actor_critic_custom.py`
 - editable lines **36–128**

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/instruction.md
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/instruction.md
@@ -33,8 +33,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `robomimic/custom_bc_loss.py`
 - editable lines **20–41**

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/instruction.md
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/instruction.md
@@ -43,8 +43,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `robomimic/custom_iql_vf.py`
 - editable lines **21–38**

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/instruction.md
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/instruction.md
@@ -30,8 +30,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `robomimic/custom_obs_encoder.py`
 - editable lines **19–46**

--- a/harbor/tasks/mls-bench__safe-rl/instruction.md
+++ b/harbor/tasks/mls-bench__safe-rl/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `omnisafe/omnisafe/algorithms/on_policy/naive_lagrange/custom_lag.py`
 - editable lines **20–20**

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `torchattacks/bench/custom_attack.py`
 - editable lines **7–56**

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/instruction.md
@@ -58,8 +58,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `torchattacks/bench/custom_attack.py`
 - editable lines **3–26**

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `torchattacks/bench/custom_attack.py`
 - editable lines **3–26**

--- a/harbor/tasks/mls-bench__security-adversarial-training/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-training/instruction.md
@@ -55,8 +55,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `torchattacks/bench/custom_adv_train.py`
 - editable lines **10–54**

--- a/harbor/tasks/mls-bench__security-backdoor-defense/instruction.md
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/instruction.md
@@ -57,8 +57,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/bench/backdoor/custom_backdoor_defense.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__security-machine-unlearning/instruction.md
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/bench/unlearning/custom_unlearning.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/instruction.md
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/instruction.md
@@ -46,8 +46,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/custom_membership_defense.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/instruction.md
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/instruction.md
@@ -48,8 +48,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `pytorch-vision/bench/poison/custom_robust_loss.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/instruction.md
@@ -58,8 +58,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `BasicTS/custom_model.py`
 - editable lines **1–75**

--- a/harbor/tasks/mls-bench__tdmpc2-planning/instruction.md
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/instruction.md
@@ -46,8 +46,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `tdmpc2/tdmpc2/common/custom_planner.py`
 - editable lines **15–120**

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/instruction.md
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/instruction.md
@@ -36,8 +36,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `tdmpc2/tdmpc2/common/custom_simnorm.py`
 - editable lines **16–43**

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/instruction.md
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/instruction.md
@@ -45,8 +45,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ts-classification/instruction.md
+++ b/harbor/tasks/mls-bench__ts-classification/instruction.md
@@ -49,8 +49,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/instruction.md
@@ -52,8 +52,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ts-imputation/instruction.md
+++ b/harbor/tasks/mls-bench__ts-imputation/instruction.md
@@ -50,8 +50,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/instruction.md
@@ -53,8 +53,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/instruction.md
@@ -49,8 +49,12 @@ You are working inside `/workspace`. The package source tree
 ## Files You May Edit
 
 You may **only** modify these files, and **only within the listed line ranges
-(inclusive, 1-indexed)**. Edits outside these ranges — or creating new files,
-or deleting existing ones — will cause your submission to be invalid.
+(inclusive, 1-indexed)**. Edits that change code outside these ranges — or creating new files, or
+deleting whole files — will cause your submission to be invalid.
+
+The line numbers mark an editable **region**, not a fixed line-count budget: you
+may add or remove lines inside it. Only code outside the editable ranges must
+stay unchanged.
 
 - `Time-Series-Library/models/Custom.py`
 - editable: **entire file**


### PR DESCRIPTION
## What

Direct edit of the **rendered** `instruction.md` for all **140** harbor tasks (`harbor/tasks/*/instruction.md`). Adds a clarifying paragraph to the **"Files You May Edit"** block and disambiguates one phrase.

## Why

The block described the edit constraint purely in terms of **absolute line numbers** ("editable lines X–Y", "invalid if outside"), with no mention of what actually happens to line numbers. Agents reading this infer they must **preserve the original line count** so their edits don't drift out of the stated range, and waste effort "keeping the line count" / squeezing replacements in-place.

But the Harbor guard (`tests/score_task.py` → `_check_editable_only`) is **content-based, not line-number-based**: code *outside* the editable region must survive byte-for-byte, while lines may be **freely added or removed inside** the region (the guard explicitly supports e.g. a 7-line stub → 30-line implementation). The instruction never told the agent this. Our own interactive harness already says it (`interactive.py`: "editing one region may shift line numbers … updated editable ranges shown after each edit"); the rendered Harbor instruction had dropped it.

## Change

- New paragraph: line ranges are a content-anchored **region**, not a fixed-length budget; you may add/remove lines inside; validity is checked by content; surrounding code must stay byte-for-byte unchanged.
- `"deleting existing ones"` → `"deleting whole files"` (the original could be misread as deleting *lines*).

## Scope / notes

- **Rendered output only.** The `harbor-adapter` template (`instruction.md.j2`) is intentionally **not** touched and **no re-render** was run, so the eval-detail strip and other rendered hand-edits are preserved. A future coordinated re-render will need the same wording ported into the template to persist this.
- 140 files changed, identical boilerplate replacement; no non-`instruction.md` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
