### PR TITLE
fix(guard): don't hard-zero correct solutions for agent scratch files

### DIFF
--- a/EDIT_RANGE_GUARD_FIX_PROPOSAL.md
+++ b/EDIT_RANGE_GUARD_FIX_PROPOSAL.md
@@ -1,0 +1,140 @@
+# Proposal: stop the edit-range guard from hard-zeroing correct solutions that leave scratch files
+
+**Component:** `tests/score_task.py :: cmd_guard` (the edit-range diff guard), rendered into every task's `tests/` dir by the Harbor adapter.
+**Severity:** false negatives — a *correct* solution scores **0** (eval never runs) because the agent left a harmless file behind.
+**Status:** fix implemented + tested below; ready to land via the adapter template.
+
+---
+
+## 1. Symptom
+
+When an agent does some experimentation and leaves a by-product inside the workspace package dir — an experiment script, a `*.bak`, a `test_*.py`, a variant of its own solution — the run gets a hard **0**, regardless of how good the actual edit is. This was reported independently by a user and reproduced while evaluating Kimi-K2.7.
+
+It hits **agents that scratch inside the package dir** (Kimi-code family is the prime example) far more than agents that scratch in `/tmp` (Opus / Codex in our data did not trigger it).
+
+## 2. Root cause
+
+`tests/test.sh` runs the guard **before** the eval and treats a guard violation as a terminal zero:
+
+```sh
+"${PYTHON_BIN}" -I score_task.py guard --task-meta ... --pristine ... --workspace ... --violation-out ...
+guard_rc=$?
+if [ "${guard_rc}" -eq 10 ]; then
+    echo "0" > /logs/verifier/reward.txt    #  <-- HARD ZERO, eval is skipped
+    exit 0
+fi
+```
+
+`cmd_guard` returns `10` for **any** workspace file that is not in the render-time manifest, whenever `allow_create=false`:
+
+```python
+# score_task.py :: cmd_guard  (current)
+if not allow_create:
+    for rel in sorted(workspace_files):
+        rel_str = rel.as_posix()
+        if rel_str in manifest:
+            continue
+        violations.append(f"created new file (allow_create=false): {rel_str}")
+...
+if violations:
+    violation_out.write_text("\n".join(violations) + "\n")
+    return 10            # -> test.sh writes reward 0, never runs the eval
+```
+
+So **creating any new file** = instant 0. But creating a new file is **not the threat model** the guard exists for. The thing worth protecting is *modification* or *deletion* of the fixed baseline (the scorer, hidden tests, data, frozen model source) — and those are handled separately (sha-compare against the manifest, deletion check, and the per-file edit-range check). A brand-new `test_idea.py` cannot tamper with the score; at worst it could shadow-import a package module, which is trivially neutralized by removing it.
+
+## 3. Evidence
+
+In our Mangrove harness the guard is *skipped* (the per-task pristine/manifest isn't staged), so we can see what these same runs score **when the eval is actually allowed to run**. They are fine solutions — the guard would have zeroed every one of them purely for leftover files:
+
+| Kimi run (task) | score with guard **skipped** | files the guard would flag → **0** |
+|---|---|---|
+| ml-clustering-algorithm | **0.580** | 18× `scikit-learn/test_*.py`, `compare.py` |
+| ts-exogenous-forecast | **0.520** | 4× `Time-Series-Library/test_*.py` |
+| llm-rl-importance-sampling | **0.472** | `verl/trainer/ppo/custom_policy_loss.py` |
+| optimization-variance-reduction | **0.463** | `opt-vr-bench/custom_vr.py.my`, `…/.sarah` |
+| optimization-multi-objective | **0.446** | `deap/custom_moea_orig.py` |
+| ai4sci-pla-binding-affinity | **0.346** | `EHIGN_PLA/sanity_train.py` |
+| llm-pretrain-optimizer | 0.286 / 0.039 | `nanoGPT/custom_pretrain_baseline.py`, `…_lookahead.py`, `…py.bak` |
+
+Every affected task has `allow_create=false`. None of the leftover files touch the scorer/tests/data — they are the agent's own scratch.
+
+## 4. The fix
+
+A newly-created file is not tampering: **remove it before the eval** (so it can't shadow-import anything) and continue, instead of failing the whole run. Modification / deletion of baseline files and out-of-range edits are still hard failures — unchanged.
+
+```diff
+--- a/tests/score_task.py
++++ b/tests/score_task.py
+@@ def cmd_guard(args):
+-    # Disallowed creation: anything in workspace that is NOT in the manifest
+-    # (= agent created it post-start).
++    # Newly-created files (present in the workspace, absent from the render-time
++    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
++    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
++    # source) — handled below. A brand-new file is, at worst, agent scratch
++    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
++    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
++    # Instead, REMOVE such files before the eval so they cannot influence it
++    # (e.g. shadow-import a package module), then continue. A task that
++    # legitimately needs the agent to author new files sets allow_create=true.
++    cleaned_created: list[str] = []
+     if not allow_create:
+         for rel in sorted(workspace_files):
+             rel_str = rel.as_posix()
+             if rel_str in manifest:
+                 continue
+-            violations.append(f"created new file (allow_create=false): {rel_str}")
++            try:
++                _safe_join(workspace_root, rel_str).unlink()
++                cleaned_created.append(rel_str)
++            except OSError:
++                pass
++        if cleaned_created:
++            workspace_files = {p for p in workspace_files
++                               if p.as_posix() not in set(cleaned_created)}
++            workspace_rel_strs = {p.as_posix() for p in workspace_files}
++            # Debug breadcrumb only — NOT a violation.
++            (violation_out.parent / "cleaned_created.txt").write_text(
++                "\n".join(cleaned_created) + "\n"
++            )
+```
+
+Notes:
+- `allow_create=true` tasks are untouched (the whole block is under `if not allow_create`).
+- `_walk_workspace` already excludes `__pycache__`, `*.pyc`, the mounted `_task` tree, and `guard_exclude` prefixes, so those are never deleted.
+- The later sha-compare loop already `continue`s on files whose `manifest.get(rel_str) is None`, so removing them first changes nothing for modification/deletion detection.
+
+## 5. Why it's safe — test matrix
+
+Harness builds a minimal task (`allow_create=false`, one editable file with range `[3,4]`, a fixed `model.py` in the manifest) and runs the **real** guard (`orig`) vs the **patched** guard (`patched`) via subprocess, exactly as `test.sh` invokes it. `rc 10` ⇒ reward 0 / eval skipped; `rc 0` ⇒ eval runs.
+
+| scenario | orig rc | patched rc | result |
+|---|---|---|---|
+| **S1** valid in-range edit **+ leftover `test_scratch.py` / `custom.py.bak`** | `10` | `0` (scratch removed) | **bug fixed** |
+| **S2** modify a fixed manifest file (`model.py`) | `10` | `10` | still caught ✓ |
+| **S3** edit a fixed line outside the editable range | `10` | `10` | still caught ✓ |
+| **S4** clean in-range edit, nothing else | `0` | `0` | unchanged ✓ |
+| **S5** delete a fixed manifest file | `10` | `10` | still caught ✓ |
+
+Only S1 changes. Every real-tampering path is preserved. (Test script: `test_guard_fix.py`, included alongside this doc.)
+
+## 6. How to land it (touches many files, but mechanically)
+
+`tests/score_task.py` is **byte-identical across all 140 tasks** (verified: single md5 across the rendered tree) — it is copied verbatim by the adapter, with **no per-task templating**. So:
+
+1. Apply the patch to the **adapter template**: `harbor_adapter/src/mls_bench/task-template/tests/score_task.py`.
+2. Re-render **only `score_task.py`** into each task's `tests/` dir (it carries no per-task data). A full task re-render is **not** required and should be avoided here, because re-rendering `task_description.md` (the instruction) produces spurious diffs — **do not re-render instructions**. Because the file is verbatim, regeneration of this one file is equivalent to copying the patched template over every `tests/score_task.py`.
+
+A one-liner equivalent (no adapter run needed) if preferred:
+```sh
+find harbor/tasks -path '*/tests/score_task.py' \
+  -exec cp harbor_adapter/.../task-template/tests/score_task.py {} \;
+```
+
+## 7. Lighter alternatives (if removing files is unwanted)
+
+- **Ignore instead of delete**: don't append a violation for created files and don't delete them. Simpler, but a created file could still shadow-import a package module during the eval; deletion closes that.
+- **Scratch allowlist**: extend `guard_exclude` with common scratch patterns (`test_*`, `*.bak`, `*_baseline*`, `*.my`, …). Narrower, but agents invent new names; the create-is-not-tampering framing is more robust.
+
+The recommended fix (delete-then-continue) is the smallest change that both removes the false-zero and keeps the eval running against a clean tree.

--- a/EDIT_RANGE_GUARD_FIX_test.py
+++ b/EDIT_RANGE_GUARD_FIX_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Test: does the cmd_guard patch (a) stop false-zeroing on agent scratch files,
+and (b) still catch real tampering? Runs the REAL GitHub guard (orig) vs the
+patched guard via subprocess on identical fixtures, exactly as test.sh invokes it:
+
+    score_task.py guard --task-meta META --pristine META/pristine \
+        --workspace WS --violation-out VIOL
+
+rc 10 => violation => reward 0 (eval skipped). rc 0 => pass (eval runs).
+"""
+import json, os, hashlib, subprocess, shutil, sys, tempfile
+from pathlib import Path
+
+ORIG = "/tmp/guardfix/score_task_orig.py"
+PATCHED = "/tmp/guardfix/score_task_patched.py"
+
+# ---- pristine package source (the "fixed" baseline) ----
+PRISTINE = {
+    "pkg/model.py": "# FIXED model definition\nclass Model:\n    def forward(self, x):\n        return x\n",
+    "pkg/custom.py": (
+        "import torch\n"            # line 1 (fixed)
+        "# EDITABLE REGION START\n"  # line 2 (fixed)
+        "def custom(x):\n"           # line 3 (editable)
+        "    return x  # baseline\n" # line 4 (editable)
+        "# EDITABLE REGION END\n"    # line 5 (fixed)  -> editable range = [3,4]
+    ),
+}
+CONFIG = {
+    "allow_create": False,
+    "files": [{"filename": "pkg/custom.py", "edit": [{"start": 3, "end": 4}]}],
+}
+
+def sha(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+def build_meta(root: Path):
+    meta = root / "meta"
+    (meta / "pristine").mkdir(parents=True)
+    for rel, txt in PRISTINE.items():
+        p = meta / "pristine" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(txt)
+    (meta / "config.json").write_text(json.dumps(CONFIG))
+    manifest = {rel: sha(txt.encode()) for rel, txt in PRISTINE.items()}
+    (meta / "pristine_manifest.json").write_text(json.dumps(manifest))
+    return meta
+
+def build_ws(root: Path, files: dict):
+    ws = root / "ws"
+    for rel, txt in files.items():
+        p = ws / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(txt)
+    return ws
+
+def run_guard(script: str, meta: Path, ws: Path):
+    viol = ws.parent / "violation.txt"
+    if viol.exists():
+        viol.unlink()
+    r = subprocess.run(
+        [sys.executable, "-I", script, "guard",
+         "--task-meta", str(meta), "--pristine", str(meta / "pristine"),
+         "--workspace", str(ws), "--violation-out", str(viol)],
+        capture_output=True, text=True,
+    )
+    msg = viol.read_text().strip() if viol.exists() else ""
+    return r.returncode, msg
+
+# valid in-range edit (only lines 3-4 changed)
+VALID_EDIT = (
+    "import torch\n# EDITABLE REGION START\n"
+    "def custom(x):\n    return torch.relu(x) * 1.5  # my solution\n"
+    "# EDITABLE REGION END\n"
+)
+# out-of-range edit (line 1 import changed = fixed line)
+OOR_EDIT = (
+    "import torch as T  # CHANGED FIXED LINE\n# EDITABLE REGION START\n"
+    "def custom(x):\n    return x\n# EDITABLE REGION END\n"
+)
+
+SCENARIOS = {
+    "S1 scratch-file (THE BUG)": {
+        "pkg/model.py": PRISTINE["pkg/model.py"],
+        "pkg/custom.py": VALID_EDIT,
+        "pkg/test_scratch.py": "# agent experiment\nprint('try idea 1')\n",
+        "pkg/custom.py.bak": "backup\n",
+    },
+    "S2 modify-fixed-file (tamper)": {
+        "pkg/model.py": "# HACKED model\nclass Model:\n    def forward(self,x):\n        return 999\n",
+        "pkg/custom.py": VALID_EDIT,
+    },
+    "S3 out-of-range edit (tamper)": {
+        "pkg/model.py": PRISTINE["pkg/model.py"],
+        "pkg/custom.py": OOR_EDIT,
+    },
+    "S4 clean in-range edit": {
+        "pkg/model.py": PRISTINE["pkg/model.py"],
+        "pkg/custom.py": VALID_EDIT,
+    },
+    "S5 delete fixed file (tamper)": {
+        # model.py intentionally absent
+        "pkg/custom.py": VALID_EDIT,
+    },
+}
+
+print(f"{'scenario':32s} | {'ORIG rc':>8} | {'PATCHED rc':>11} | verdict")
+print("-" * 86)
+EXPECT = {  # (orig_rc, patched_rc) expected
+    "S1 scratch-file (THE BUG)": (10, 0),
+    "S2 modify-fixed-file (tamper)": (10, 10),
+    "S3 out-of-range edit (tamper)": (10, 10),
+    "S4 clean in-range edit": (0, 0),
+    "S5 delete fixed file (tamper)": (10, 10),
+}
+allok = True
+for name, files in SCENARIOS.items():
+    o_rc = p_rc = None
+    for script, tag in ((ORIG, "o"), (PATCHED, "p")):
+        d = Path(tempfile.mkdtemp())
+        meta = build_meta(d)
+        ws = build_ws(d, files)
+        rc, msg = run_guard(script, meta, ws)
+        if tag == "o": o_rc, o_msg = rc, msg
+        else:
+            p_rc, p_msg = rc, msg
+            # for S1, also confirm scratch was removed by the patch
+            removed = not (ws / "pkg/test_scratch.py").exists()
+        shutil.rmtree(d, ignore_errors=True)
+    exp = EXPECT[name]
+    ok = (o_rc, p_rc) == exp
+    allok &= ok
+    extra = ""
+    if name.startswith("S1"):
+        extra = f"  (patch removed scratch: {removed})"
+    print(f"{name:32s} | {o_rc:>8} | {p_rc:>11} | {'OK' if ok else 'MISMATCH exp='+str(exp)}{extra}")
+
+print("-" * 86)
+print("ALL EXPECTED:", allok)
+print()
+print("Interpretation: rc 10 -> reward.txt=0 (eval skipped); rc 0 -> eval runs.")

--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
@@ -317,14 +317,34 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Disallowed creation: anything in workspace that is NOT in the manifest
-    # (= agent created it post-start).
+    # Newly-created files (present in the workspace, absent from the render-time
+    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
+    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
+    # source) — handled below. A brand-new file is, at worst, agent scratch
+    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
+    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
+    # Instead, REMOVE such files before the eval so they cannot influence it
+    # (e.g. shadow-import a package module), then continue. A task that
+    # legitimately needs the agent to author new files sets allow_create=true.
+    cleaned_created: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
-            violations.append(f"created new file (allow_create=false): {rel_str}")
+            try:
+                _safe_join(workspace_root, rel_str).unlink()
+                cleaned_created.append(rel_str)
+            except OSError:
+                pass
+        if cleaned_created:
+            workspace_files = {p for p in workspace_files
+                               if p.as_posix() not in set(cleaned_created)}
+            workspace_rel_strs = {p.as_posix() for p in workspace_files}
+            # Debug breadcrumb only — NOT a violation.
+            (violation_out.parent / "cleaned_created.txt").write_text(
+                "\n".join(cleaned_created) + "\n"
+            )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.


### PR DESCRIPTION
The edit-range guard (score_task.py cmd_guard) returns rc 10 — which test.sh turns into reward 0 with the eval skipped — for ANY file the agent created that isn't in the render-time manifest, whenever allow_create=false. But creating a new file is not the threat model: the guard protects against modification / deletion of the fixed baseline (scorer/tests/data/model), which are checked separately. A leftover experiment script / *.bak / test_*.py thus zeroes an otherwise-correct solution before the eval even runs.

Repro: Kimi-code agents routinely leave scratch inside the package dir; e.g. ml-clustering-algorithm scored 0.58 (guard skipped) yet would be a hard 0 under the guard purely for 18 leftover scikit-learn/test_*.py files.

Fix: created (non-manifest) files are removed before the eval — so they can't shadow-import a package module — instead of failing the run. Modification, deletion, and out-of-range edits remain hard failures. allow_create=true tasks are unaffected. Verified with EDIT_RANGE_GUARD_FIX_test.py (5 scenarios: only the false-zero changes 10->0; all real-tampering cases stay 10).

Applied verbatim to all 140 rendered tests/score_task.py; the same one-line change must also go into the adapter template so it survives regeneration. Do NOT re-render task_description.md.

See EDIT_RANGE_GUARD_FIX_PROPOSAL.md for full evidence + test matrix.