### PR TITLE
fix(guard): harden created-file cleanup (symlink-safe, scope-limited)

### DIFF
--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
@@ -326,24 +326,37 @@ def cmd_guard(args: argparse.Namespace) -> int:
     # Instead, REMOVE such files before the eval so they cannot influence it
     # (e.g. shadow-import a package module), then continue. A task that
     # legitimately needs the agent to author new files sets allow_create=true.
+    #
+    # Only files under a guarded package prefix are cleaned — those are the only
+    # ones that can shadow-import a protected module; created files elsewhere are
+    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
+    # _safe_join (which resolve()s symlinks): we must remove the created entry
+    # itself — never a symlink's *target* (which could be a manifest file) — and
+    # must not raise on a symlink that points outside the workspace.
     cleaned_created: list[str] = []
+    failed_clean: list[str] = []
     if not allow_create:
         for rel in sorted(workspace_files):
             rel_str = rel.as_posix()
             if rel_str in manifest:
                 continue
+            if not rel.parts or rel.parts[0] not in guarded_prefixes:
+                continue
             try:
-                _safe_join(workspace_root, rel_str).unlink()
+                (workspace_root / rel_str).unlink()
                 cleaned_created.append(rel_str)
-            except OSError:
-                pass
+            except (OSError, ValueError):
+                failed_clean.append(rel_str)
         if cleaned_created:
+            removed = set(cleaned_created)
             workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in set(cleaned_created)}
+                               if p.as_posix() not in removed}
             workspace_rel_strs = {p.as_posix() for p in workspace_files}
+        if cleaned_created or failed_clean:
             # Debug breadcrumb only — NOT a violation.
+            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
             (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(cleaned_created) + "\n"
+                "\n".join(lines) + "\n"
             )
 
     # Disallowed deletion: anything in manifest under a guarded prefix that


### PR DESCRIPTION
Follow-up to #48. Code review (+ independent repro) found two real edge-case bugs in the created-file cleanup:

1. Symlink target deletion: _safe_join() resolve()s symlinks, so unlink() removed a symlink's TARGET. An agent creating an intra-workspace symlink (pkg/link.py -> pkg/model.py) silently DELETED the fixed manifest file model.py; the deletion check used stale state and returned rc 0, so the eval then ran against a corrupted tree.
2. External symlink crash: a symlink resolving outside the workspace made _safe_join() raise ValueError (not caught by 'except OSError'), crashing the guard (rc 1) -> test.sh writes reward 0, eval skipped.

Fixes:
- unlink the LITERAL path (workspace_root / rel) instead of _safe_join(...): removes the created entry itself, never a symlink's target, and never resolve()s outside the workspace.
- restrict cleanup to files under a guarded package prefix (created files elsewhere are harmless and left untouched).
- catch (OSError, ValueError); record unlink failures in cleaned_created.txt instead of silently leaving the file.

Verified: S1-S5 unchanged (scratch fixed, all real-tamper cases stay rc 10); S6 intra-symlink keeps model.py (was DELETED); S7 external symlink rc 0 (was crash rc 1); non-guarded creates left alone; allow_create true/None correct.

Apply the same change to the adapter template so it survives regeneration; do NOT re-render task_description.md.