### PR TITLE
fix(harbor): self-heal lm-eval dataset name aliases in offline cache

### DIFF
--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/environment/_scaffold/lm-evaluation-harness/nanogpt_lm_eval.py
@@ -163,6 +163,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -172,6 +212,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")


### PR DESCRIPTION
## Problem

The rendered Harbor lm-eval step (`nanogpt_lm_eval.py`, in 12 `llm-pretrain-*` / `llm-kv-structural-reduction` tasks) crashes **offline** on `winogrande`:

- lm-eval renamed winogrande's `dataset_path` from the bare `winogrande` (old) to the namespaced `allenai/winogrande` (HF Hub canonicalization, lm-eval ≥0.4.x).
- The offline datasets cache baked into the base image holds winogrande under the **old bare** name (`winogrande/`), but the pip-installed lm-eval requests `allenai/winogrande` → looks for `allenai___winogrande/` → not found → `ConnectionError` under `HF_DATASETS_OFFLINE=1`.
- `simple_evaluate()` runs all 4 subtasks in one call, so this crashes the **whole** eval step (no `TEST_METRICS` line → no metrics).

hellaswag / piqa / arc already work because the cache carries **both** name variants for them; winogrande was the lone omission.

## Fix

`nanogpt_lm_eval.py` now calls `_bridge_dataset_name_aliases()` before any dataset load. It creates reciprocal symlinks in the offline HF cache for the known bare↔namespaced rename pairs (`winogrande↔allenai___winogrande`, `hellaswag↔Rowan___hellaswag`, `piqa↔baber___piqa`, `ai2_arc↔allenai___ai2_arc`). Same data, just an upstream repo rename.

- **Self-heals an already-baked image at eval time — no base-image rebuild needed.**
- Idempotent, best-effort (never raises into the eval).
- Applies to all 12 rendered tasks that run the nanoGPT lm-eval step (identical generated file).

Dev-side companion fixes (separate repo): cache both winogrande names in the data-prep script, pin `lm-eval==0.4.11`, and a ratchet guard against newly-introduced unpinned pip deps.