### PR TITLE
fix(build): sync offline-image fixes into harbor-adapter pkg_configs

### DIFF
--- a/vendor/data_scripts/lm-evaluation-harness/prepare_datasets.py
+++ b/vendor/data_scripts/lm-evaluation-harness/prepare_datasets.py
@@ -26,7 +26,14 @@ DATASETS = [
     ("baber/piqa", None),
     ("allenai/ai2_arc", "ARC-Easy"),
     ("allenai/ai2_arc", "ARC-Challenge"),
+    # lm-eval renamed winogrande's dataset_path from the bare `winogrande`
+    # (old convention) to the namespaced `allenai/winogrande` (>=0.4.x).
+    # Cache both names so offline lookup matches regardless of which lm-eval
+    # version the eval image ends up resolving — same pattern as hellaswag /
+    # piqa above. Without the namespaced variant, an image built with a newer
+    # lm-eval looks for `allenai___winogrande/` and fails offline.
     ("winogrande", "winogrande_xl"),
+    ("allenai/winogrande", "winogrande_xl"),
 ]
 
 

--- a/vendor/pkg_configs/LLaDA/config.json
+++ b/vendor/pkg_configs/LLaDA/config.json
@@ -6,7 +6,8 @@
     "pip install --no-cache-dir sympy regex",
     "mkdir -p /opt/huggingface /data/llada-instruct",
     "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModel, AutoTokenizer; AutoTokenizer.from_pretrained('GSAI-ML/LLaDA-8B-Base', trust_remote_code=True); AutoModel.from_pretrained('GSAI-ML/LLaDA-8B-Base', trust_remote_code=True, torch_dtype='auto')\"",
-    "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModel, AutoTokenizer; AutoTokenizer.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True); AutoModel.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True, torch_dtype='auto')\""
+    "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModel, AutoTokenizer; AutoTokenizer.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True); AutoModel.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True, torch_dtype='auto')\"",
+    "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModelForCausalLM, AutoTokenizer; AutoTokenizer.from_pretrained('openai-community/gpt2-large'); AutoModelForCausalLM.from_pretrained('openai-community/gpt2-large')\""
   ],
   "env": {
     "HF_HOME": "/opt/huggingface",
@@ -15,6 +16,9 @@
     "LLADA_INSTRUCT_PATH": "/data/llada-instruct",
     "PYTHONPATH": "/workspace/LLaDA:${PYTHONPATH}"
   },
+  "host_data_prepare_requirements": [
+    "huggingface_hub>=0.20"
+  ],
   "data_deps": [
     {
       "name": "llada-instruct",

--- a/vendor/pkg_configs/LLaDA/config.json
+++ b/vendor/pkg_configs/LLaDA/config.json
@@ -4,6 +4,8 @@
     "apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*",
     "pip install --no-cache-dir 'transformers>=4.46,<4.49' accelerate sentencepiece protobuf",
     "pip install --no-cache-dir sympy regex",
+    "pip install --no-cache-dir mauve-text nltk",
+    "python -c \"import nltk; nltk.download('punkt'); nltk.download('punkt_tab')\"",
     "mkdir -p /opt/huggingface /data/llada-instruct",
     "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModel, AutoTokenizer; AutoTokenizer.from_pretrained('GSAI-ML/LLaDA-8B-Base', trust_remote_code=True); AutoModel.from_pretrained('GSAI-ML/LLaDA-8B-Base', trust_remote_code=True, torch_dtype='auto')\"",
     "HF_HOME=/opt/huggingface python -c \"from transformers import AutoModel, AutoTokenizer; AutoTokenizer.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True); AutoModel.from_pretrained('Dream-org/Dream-v0-Instruct-7B', trust_remote_code=True, torch_dtype='auto')\"",

--- a/vendor/pkg_configs/lm-evaluation-harness/config.json
+++ b/vendor/pkg_configs/lm-evaluation-harness/config.json
@@ -3,7 +3,7 @@
   "install_cmds": [
     "apt-get -o APT::Sandbox::User=root update -q && DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y git && rm -rf /var/lib/apt/lists/*",
     "pip install --no-cache-dir 'datasets<3.0'",
-    "pip install --no-cache-dir 'lm-eval>=0.4.0' tiktoken",
+    "pip install --no-cache-dir 'lm-eval==0.4.11' tiktoken",
     "pip install flash-linear-attention",
     "pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cu124",
     "pip install --no-cache-dir --force-reinstall triton==3.2.0",
@@ -13,7 +13,7 @@
   ],
   "local_install_cmds": [
     "pip install --no-cache-dir 'datasets<3.0'",
-    "pip install --no-cache-dir 'lm-eval>=0.4.0' tiktoken",
+    "pip install --no-cache-dir 'lm-eval==0.4.11' tiktoken",
     "pip install flash-linear-attention",
     "pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cu124",
     "pip install --no-cache-dir --force-reinstall triton==3.2.0",
@@ -33,7 +33,8 @@
   },
   "host_data_prepare_requirements": [
     "datasets<3.0",
-    "lm-eval>=0.4.0",
+    "huggingface-hub<1.0",
+    "lm-eval==0.4.11",
     "tiktoken"
   ],
   "data_deps": [

--- a/vendor/pkg_configs/lm-evaluation-harness/pre_edit.py
+++ b/vendor/pkg_configs/lm-evaluation-harness/pre_edit.py
@@ -167,6 +167,46 @@ class NanoGPTLM(LM):
         return results
 
 
+def _bridge_dataset_name_aliases():
+    """Make the offline HF datasets cache resilient to lm-eval's bare<->namespaced
+    dataset-repo renames (winogrande<->allenai/winogrande, hellaswag<->Rowan/hellaswag,
+    piqa<->baber/piqa, ai2_arc<->allenai/ai2_arc).
+
+    The cache may have been baked under either name depending on which lm-eval
+    version built it; the installed lm-eval may request the other. Same data,
+    just an upstream repo rename. Create reciprocal symlinks so load_dataset()
+    resolves the dir regardless of which name is requested -- this self-heals an
+    already-baked cache offline, without rebuilding the image. Idempotent and
+    best-effort: it never raises into the eval.
+    """
+    aliases = [
+        ("winogrande", "allenai___winogrande"),
+        ("hellaswag", "Rowan___hellaswag"),
+        ("piqa", "baber___piqa"),
+        ("ai2_arc", "allenai___ai2_arc"),
+    ]
+    cache_dirs = []
+    if os.environ.get("HF_DATASETS_CACHE"):
+        cache_dirs.append(os.environ["HF_DATASETS_CACHE"])
+    cache_dirs.append(os.path.expanduser("~/.cache/huggingface/datasets"))
+    seen = set()
+    for cache_dir in cache_dirs:
+        if cache_dir in seen or not os.path.isdir(cache_dir):
+            continue
+        seen.add(cache_dir)
+        for bare, namespaced in aliases:
+            pa = os.path.join(cache_dir, bare)
+            pb = os.path.join(cache_dir, namespaced)
+            for src, dst in ((pa, pb), (pb, pa)):
+                if os.path.exists(src) and not os.path.lexists(dst):
+                    try:
+                        os.symlink(os.path.basename(src), dst)
+                        print(f"[cache-alias] {os.path.basename(dst)} -> "
+                              f"{os.path.basename(src)} in {cache_dir}", flush=True)
+                    except OSError:
+                        pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="nanoGPT lm-eval benchmark")
     parser.add_argument("--checkpoint", required=True, help="Path to ckpt_{label}.pt")
@@ -176,6 +216,10 @@ def main():
     parser.add_argument("--batch_size", type=int, default=1)
     parser.add_argument("--device", default="cuda")
     args = parser.parse_args()
+
+    # Bridge bare<->namespaced dataset cache dir names before any dataset loads,
+    # so offline eval survives lm-eval's upstream dataset-repo renames.
+    _bridge_dataset_name_aliases()
 
     print(f"Loading model from {args.checkpoint}")
     print(f"Model source: {args.source}")

--- a/vendor/pkg_configs/nanoGPT/config.json
+++ b/vendor/pkg_configs/nanoGPT/config.json
@@ -5,7 +5,7 @@
     "pip install tiktoken numpy einops safetensors huggingface_hub transformers accelerate",
     "pip install flash-linear-attention",
     "pip install --no-cache-dir 'datasets<3.0'",
-    "pip install --no-cache-dir 'lm-eval>=0.4.0'",
+    "pip install --no-cache-dir 'lm-eval==0.4.11'",
     "pip install --no-cache-dir torch==2.6.0 --index-url https://download.pytorch.org/whl/cu124",
     "pip install --no-cache-dir --force-reinstall triton==3.2.0",
     "CUDA_HOME=/usr/local/cuda TORCH_CUDA_ARCH_LIST='8.0;9.0' CXXFLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' pip install --no-build-isolation causal-conv1d==1.6.1",
@@ -23,7 +23,7 @@
     "pip install tiktoken numpy einops safetensors huggingface_hub transformers accelerate",
     "pip install --no-build-isolation --no-deps {project_root}/vendor/external_packages/flash-linear-attention",
     "pip install --no-cache-dir 'datasets<3.0'",
-    "pip install --no-cache-dir 'lm-eval>=0.4.0'",
+    "pip install --no-cache-dir 'lm-eval==0.4.11'",
     "pip install --no-cache-dir --force-reinstall triton==3.2.0",
     "pip install --no-cache-dir --force-reinstall nvidia-nccl-cu12==2.21.5",
     "python -c \"import ctypes; v=ctypes.c_int(); ctypes.CDLL('libnccl.so.2').ncclGetVersion(ctypes.byref(v)); assert v.value == 22105, f'Expected NCCL 2.21.5 but got {v.value}'\"",
@@ -34,9 +34,9 @@
   ],
   "host_data_prepare_requirements": [
     "datasets<3.0",
-    "lm-eval>=0.4.0",
+    "lm-eval==0.4.11",
     "tiktoken",
-    "huggingface_hub",
+    "huggingface-hub<1.0",
     "numpy"
   ],
   "env": {


### PR DESCRIPTION
The harbor base images are built from `vendor/pkg_configs/<pkg>/` on this branch (`harbor_adapter/scripts/build_base_image.py`). Those configs had drifted from the dev source of truth, so a public **rebuild** would regenerate the OLD broken images even though the published `bohanlyu2022/mlsbench-*` images are already fixed. This syncs the five build-relevant files so the public build recipe reproduces the fixed images.

### Files
- **`pkg_configs/LLaDA/config.json`** — pre-download `openai-community/gpt2-large` (the gen_ppl/MAUVE reference LM the `dream_text` eval loads offline) + add `host_data_prepare_requirements`. Without it, `llm-dllm-demask-strategy` text eval crashes offline.
- **`pkg_configs/nanoGPT/config.json`** + **`pkg_configs/lm-evaluation-harness/config.json`** — pin `lm-eval==0.4.11` (was unbounded `>=0.4.0`) and `huggingface-hub<1.0`. The unbounded `lm-eval` floated to a release that renamed winogrande's `dataset_path` (`winogrande` → `allenai/winogrande`), breaking the offline-baked cache.
- **`data_scripts/lm-evaluation-harness/prepare_datasets.py`** — also cache the namespaced `allenai/winogrande` variant (same bare↔namespaced pattern already used for hellaswag/piqa).
- **`pkg_configs/lm-evaluation-harness/pre_edit.py`** — add `_bridge_dataset_name_aliases()` to the generated `nanogpt_lm_eval.py` so an already-baked cache self-heals the bare↔namespaced rename at eval time.

These mirror the already-pushed `bohanlyu2022/mlsbench-(harbor-)llada` and `harbor-nanogpt`/`harbor-lm-evaluation-harness` images. Rendered-side (main) counterparts are in PR #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)