### PR TITLE
fix: editable-file path must match the edit contract (source + rendered, 20 tasks)

### DIFF
--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/instruction.md
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/instruction.md
@@ -13,7 +13,7 @@ Diffusion models learn rich priors `p(x)` over signal distributions. For inverse
 - **LGD — Loss-Guided Diffusion** (Song et al., "Loss-Guided Diffusion Models for Plug-and-Play Controllable Generation", ICML 2023). Estimates the guidance term via Monte Carlo sampling around the denoised estimate to reduce bias of point-estimate approximations.
 
 ## What to Implement
-Implement the `Custom` class in `algo/custom.py`. You must implement:
+Implement the `Custom` class in `InverseBench/algo/custom.py`. You must implement:
 1. `__init__`: Set up your algorithm (schedulers, optimizers, hyperparameters).
 2. `inference(observation, num_samples)`: Given observation `y`, return reconstructed `x`.
 
@@ -28,7 +28,7 @@ Implement the `Custom` class in `algo/custom.py`. You must implement:
 The pretrained denoiser, the forward-operator definitions, and the evaluation problems are fixed; the algorithm only chooses how to combine these pieces.
 
 ## Editable Region
-The entire `algo/custom.py` file is editable. You may define any helper classes/functions within this file.
+The entire `InverseBench/algo/custom.py` file is editable. You may define any helper classes/functions within this file.
 
 
 ## Your Workspace

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/instruction.md
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/instruction.md
@@ -19,7 +19,7 @@ sizes, and edge densities, without over-specializing to a single scale or
 cardinality pattern.
 
 ## Task
-Implement a causal discovery algorithm in `bench/custom_algorithm.py`. The
+Implement a causal discovery algorithm in `causal-bnlearn/bench/custom_algorithm.py`. The
 `run_causal_discovery(X)` function receives integer-encoded discrete
 observational data and must return the estimated CPDAG as a
 `causallearn.graph.GeneralGraph.GeneralGraph` object.

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/instruction.md
@@ -15,7 +15,7 @@ robustness across sparse and denser graphs and across noise levels, and the
 method should not rely on dataset-specific constants.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a `causallearn.graph.GeneralGraph.GeneralGraph` representing the
 estimated CPDAG.
 

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/instruction.md
@@ -18,7 +18,7 @@ JMLR 7, 2006.
 The method should handle moderate-to-large variable counts and avoid assuming a single fixed noise distribution or graph family. Data is generated from synthetic DAGs with signed linear edge weights and independent non-Gaussian noise.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a directed DAG (skeleton + correct edge orientation) compatible with the
 benchmark evaluation.
 

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/instruction.md
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/instruction.md
@@ -22,7 +22,7 @@ types (MLP, GP, polynomial, sigmoid), and (4) robustness when noise is
 Gaussian, where ANM identifiability becomes more delicate.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a directed DAG compatible with the benchmark evaluation.
 
 ## Reference baselines

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/instruction.md
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/instruction.md
@@ -9,7 +9,7 @@ conditional generation quality on image-to-image translation tasks under a
 strict per-sample budget on the number of denoiser calls.
 
 Implement the algorithm inside the `sample_custom_bridge` function in
-`ddbm/karras_diffusion.py`. The evaluation pipeline calls this function to
+`dbim-codebase/ddbm/karras_diffusion.py`. The evaluation pipeline calls this function to
 generate target images from source conditions.
 
 ## Background

--- a/harbor/tasks/mls-bench__pde-design-solver/instruction.md
+++ b/harbor/tasks/mls-bench__pde-design-solver/instruction.md
@@ -3,7 +3,7 @@
 # Industrial CFD Design: Custom Neural Operator Design
 
 ## Objective
-Design and implement a custom neural operator for industrial aerodynamic design prediction on 3D unstructured point clouds. Your code goes in the `Model` class in `models/Custom.py`. Reference implementations (PointNet, GraphSAGE, Graph_UNet, Transolver) from Neural-Solver-Library are provided as read-only context.
+Design and implement a custom neural operator for industrial aerodynamic design prediction on 3D unstructured point clouds. Your code goes in the `Model` class in `Neural-Solver-Library/models/Custom.py`. Reference implementations (PointNet, GraphSAGE, Graph_UNet, Transolver) from Neural-Solver-Library are provided as read-only context.
 
 ## Background
 The task targets point-cloud / mesh-based neural operators for steady aerodynamic design prediction. Key reference architectures:
@@ -29,7 +29,7 @@ forward(self, x, fx, T=None, geo=None) -> output
 Key `args` attributes: `n_hidden`, `n_layers`, `n_heads`, `space_dim` (spatial dimensionality of the mesh), `fun_dim=7`, `out_dim` (number of predicted flow-field channels), `act`, `mlp_ratio`, `dropout`, `geotype` (`unstructured`), `radius` (for graph construction), `slice_num` (for Transolver-style physics attention).
 
 ## Hyperparameter Override (`CONFIG_OVERRIDES`)
-The per-dataset shell scripts under `scripts/` default to `--n_hidden 128 --slice_num 32`. Different model families need different widths to be competitive — for example Transolver uses 256 in the original paper, while PointNet and Graph_UNet typically use much smaller widths. To set per-method values, edit the `CONFIG_OVERRIDES` dict at the bottom of `models/Custom.py`:
+The per-dataset shell scripts under `scripts/` default to `--n_hidden 128 --slice_num 32`. Different model families need different widths to be competitive — for example Transolver uses 256 in the original paper, while PointNet and Graph_UNet typically use much smaller widths. To set per-method values, edit the `CONFIG_OVERRIDES` dict at the bottom of `Neural-Solver-Library/models/Custom.py`:
 
 ```python
 # Allowed keys: n_hidden (int), slice_num (int).

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/instruction.md
@@ -11,7 +11,7 @@ Score-based query black-box attacks assume the attacker can query the victim mod
 Representative algorithms include the random-search-based Square Attack (Andriushchenko et al., 2020, arXiv:1912.00049), gradient-free SPSA-based attacks (Uesato et al., 2018, arXiv:1802.05666), and pixel-coordinate random search baselines. Across these methods the central tradeoff is between per-step exploration (which helps escape local minima) and per-step exploitation (which keeps the query budget low).
 
 ## Objective
-Implement a better black-box attack in `bench/custom_attack.py`:
+Implement a better black-box attack in `torchattacks/bench/custom_attack.py`:
 
 - Threat model: query black-box (no gradient access, only model logits).
 - Constraint: `||x_adv - x||_inf <= eps`.

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/instruction.md
@@ -11,7 +11,7 @@ Sparse adversarial attacks differ from dense `L_p` attacks in that the perturbat
 Representative sparse-attack algorithms include the Jacobian Saliency Map Attack JSMA (Papernot et al., 2016, arXiv:1511.07528), the differential-evolution One-Pixel attack (Su et al., 2019, arXiv:1710.08864), the geometry-inspired SparseFool (Modas et al., CVPR 2019, arXiv:1811.02248), the random-search Sparse-RS framework (Croce et al., AAAI 2022, arXiv:2006.12834), and Pixle, a fast pixel-rearrangement black-box attack (Pomponi et al., 2022, arXiv:2202.02236).
 
 ## Objective
-Implement a stronger sparse attack in `bench/custom_attack.py`. The method should maximize attack success rate under a strict `L0` perturbation budget:
+Implement a stronger sparse attack in `torchattacks/bench/custom_attack.py`. The method should maximize attack success rate under a strict `L0` perturbation budget:
 
 - Threat model: full model access for custom attack implementation (gradients permitted).
 - Norm constraint: number of modified spatial pixels is bounded.

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/instruction.md
@@ -9,7 +9,7 @@ Can you design a stronger white-box `L_inf` evasion attack under a small `eps` b
 White-box evasion attacks assume the attacker has full access to the model, including its parameters and gradients. The classical first-order attack is FGSM (Goodfellow et al., 2015, arXiv:1412.6572), a one-step sign-of-gradient attack. Iterative variants such as PGD (Madry et al., 2018, arXiv:1706.06083) and momentum iterative FGSM, MI-FGSM (Dong et al., CVPR 2018, arXiv:1710.06081), refine the perturbation through multiple gradient steps. AutoAttack (Croce and Hein, ICML 2020, arXiv:2003.01690) is a parameter-free ensemble of two adaptive PGD variants together with FAB and Square Attack and is widely used as a strong reference attack.
 
 ## Objective
-Implement a stronger white-box `L_inf` attack in `bench/custom_attack.py`. The method should maximize ASR under a strict perturbation budget:
+Implement a stronger white-box `L_inf` attack in `torchattacks/bench/custom_attack.py`. The method should maximize ASR under a strict perturbation budget:
 
 - Threat model: white-box (full model access, including gradients).
 - Norm constraint: `||x_adv - x||_inf <= eps`.

--- a/harbor/tasks/mls-bench__security-adversarial-training/instruction.md
+++ b/harbor/tasks/mls-bench__security-adversarial-training/instruction.md
@@ -9,7 +9,7 @@ How can we design better adversarial training methods to enhance model robustnes
 Adversarial training is the most effective approach for improving neural-network robustness against adversarial examples. The standard method (Madry et al., 2018, arXiv:1706.06083) trains on PGD-generated adversarial examples using cross-entropy loss but suffers from a tradeoff between clean accuracy and robust accuracy. Advanced methods such as TRADES (Zhang et al., ICML 2019, arXiv:1901.08573) and MART (Wang et al., ICLR 2020, OpenReview rklOg6EFwS) address this through different loss formulations that decouple the robustness objective from clean classification. AWP (Wu, Xia, Wang, NeurIPS 2020, arXiv:2004.05884) further regularizes the flatness of the weight loss landscape and combines naturally with TRADES-style training.
 
 ## Task
-Implement a novel adversarial training method in `bench/custom_adv_train.py` by modifying the `AdversarialTrainer` class. Your method should improve robust accuracy against white-box `L_inf` attacks while maintaining reasonable clean accuracy.
+Implement a novel adversarial training method in `torchattacks/bench/custom_adv_train.py` by modifying the `AdversarialTrainer` class. Your method should improve robust accuracy against white-box `L_inf` attacks while maintaining reasonable clean accuracy.
 
 ## Editable Interface
 You must implement the `AdversarialTrainer` class with two methods:

--- a/harbor/tasks/mls-bench__security-backdoor-defense/instruction.md
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/instruction.md
@@ -9,7 +9,7 @@ How can we design a better poisoned-sample scoring rule that identifies backdoor
 Backdoor attacks (BadNets: Gu, Dolan-Gavitt, Garg, 2017, arXiv:1708.06733; Blended attack: Chen et al., 2017, arXiv:1712.05526) implant a trigger pattern into a subset of training examples and relabel them to an attacker-chosen target class. Models trained on this data retain high clean accuracy while also predicting the target label whenever the trigger appears. Many defenses try to identify suspicious points using feature statistics (Spectral Signatures: Tran, Li, Madry, NeurIPS 2018, arXiv:1811.00636), confidence patterns, or clustering structure (Activation Clustering: Chen et al., 2018, arXiv:1811.03728) before retraining on the filtered set, while pruning-style defenses (Fine-Pruning: Liu, Dolan-Gavitt, Garg, 2018, arXiv:1805.12185) operate on activations of suspicious neurons.
 
 ## Task
-Implement a stronger backdoor defense in `bench/backdoor/custom_backdoor_defense.py`. The fixed harness will:
+Implement a stronger backdoor defense in `pytorch-vision/bench/backdoor/custom_backdoor_defense.py`. The fixed harness will:
 
 1. Construct a poisoned training set for a fixed trigger pattern.
 2. Train a victim model on the poisoned data.

--- a/harbor/tasks/mls-bench__security-machine-unlearning/instruction.md
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/instruction.md
@@ -11,7 +11,7 @@ Machine unlearning methods approximate the effect of retraining without the dele
 The harness first pretrains a standard vision model on an image-classification training set. After pretraining, a single class is designated as the forget set. The unlearning method then runs for a fixed number of epochs, receiving both retain-set and forget-set minibatches each step, with an Adam optimizer (`lr = 0.001`).
 
 ## Task
-Implement a better unlearning rule in `bench/unlearning/custom_unlearning.py`. The fixed harness trains an initial model, defines a forget split, and then applies your update rule for a fixed number of unlearning steps using retain and forget minibatches.
+Implement a better unlearning rule in `pytorch-vision/bench/unlearning/custom_unlearning.py`. The fixed harness trains an initial model, defines a forget split, and then applies your update rule for a fixed number of unlearning steps using retain and forget minibatches.
 
 Your method should lower forget-set memorization while preserving retained-task accuracy.
 

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/instruction.md
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/instruction.md
@@ -11,7 +11,7 @@ A fraction of poisoned (label-flipped) training labels can disproportionately di
 This task uses research-scale models trained on full datasets with standard SGD + CosineAnnealing.
 
 ## Task
-Implement a better poison-robust objective in `bench/poison/custom_robust_loss.py`. The fixed harness injects random label-flip corruption (`(original + 1) % num_classes`) into the training set, trains with your loss, and evaluates on a clean test set.
+Implement a better poison-robust objective in `pytorch-vision/bench/poison/custom_robust_loss.py`. The fixed harness injects random label-flip corruption (`(original + 1) % num_classes`) into the training set, trains with your loss, and evaluates on a clean test set.
 
 Your method should improve clean test accuracy under poisoning while reducing how much the model memorizes poisoned labels. The approach must be modular and transferable across architectures and datasets.
 

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/instruction.md
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/instruction.md
@@ -9,7 +9,7 @@ What modular reconstruction-based component (sequence representation, training o
 Reconstruction-based anomaly detection trains a model to reproduce normal input windows and flags points where the reconstruction error exceeds a threshold. The Time-Series-Library (Wu et al., ICLR 2023) standardizes this setup with a fixed evaluation harness: the model only needs to output a reconstruction for each input window; the framework handles scoring and threshold selection automatically.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a window `x_enc` of shape `[batch, seq_len, enc_in]`, return a reconstruction of the same shape. The framework computes the score, threshold, and metrics.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a window `x_enc` of shape `[batch, seq_len, enc_in]`, return a reconstruction of the same shape. The framework computes the score, threshold, and metrics.
 
 ## Model Interface
 ```python

--- a/harbor/tasks/mls-bench__ts-classification/instruction.md
+++ b/harbor/tasks/mls-bench__ts-classification/instruction.md
@@ -9,7 +9,7 @@ Can a single classification component (temporal encoder + channel-interaction + 
 Standard multivariate time series classification benchmarks cover diverse signal types — datasets vary widely in sequence length, channel count, number of classes, sampling rate, and noise characteristics, making them a stress test for "general-purpose" temporal encoders. The Time-Series-Library protocol (Wu et al., ICLR 2023) standardizes train/test splits, padding to a common per-dataset length, RAdam optimization, cross-entropy loss, and accuracy reporting.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a padded input window plus a binary padding mask, return class logits.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a padded input window plus a binary padding mask, return class logits.
 
 ## Model Interface
 ```python

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/instruction.md
@@ -9,7 +9,7 @@ What architectural component best fuses *exogenous* covariates (additional obser
 Many real-world forecasting tasks present a designated target variable accompanied by side-information channels (weather covariates for energy load, exogenous prices, related sensors). The Time-Series-Library `features=MS` mode formalizes this: all variables are fed into the model, but only the last channel (the target) is scored. Recent methods such as TimeXer (Wang et al., NeurIPS 2024) explicitly separate endogenous (patch-level) and exogenous (variate-level) representations and fuse them via cross-attention; iTransformer (Liu et al., ICLR 2024) treats every channel as a token and uses attention across channels; PatchTST (Nie et al., ICLR 2023) takes the channel-independent route and ignores cross-channel structure entirely. The contribution space here is the exogenous-fusion component itself.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]` where `c_out == enc_in`; the harness slices `outputs[:, :, -1:]` so only the final (target) channel is scored.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]` where `c_out == enc_in`; the harness slices `outputs[:, :, -1:]` so only the final (target) channel is scored.
 
 ## Model Interface
 ```python

--- a/harbor/tasks/mls-bench__ts-imputation/instruction.md
+++ b/harbor/tasks/mls-bench__ts-imputation/instruction.md
@@ -9,7 +9,7 @@ What modular imputation component (mask-aware temporal modeling, cross-channel d
 Time series imputation under random masking is a canonical "fill-in-the-blanks" benchmark for temporal models. The Time-Series-Library protocol (Wu et al., ICLR 2023) masks a fixed fraction of observed entries uniformly at random, hands the model both the masked sequence and a binary observation mask, and scores reconstruction error only at masked positions. This isolates the model's ability to infer missing values from surrounding temporal context and from correlated channels.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a partially-masked input window and a binary observation mask, return a fully reconstructed sequence.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a partially-masked input window and a binary observation mask, return a fully reconstructed sequence.
 
 ## Model Interface
 ```python

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/instruction.md
@@ -9,7 +9,7 @@ What forecasting component (sequence modeling, decomposition, cross-variable att
 Long-term multivariate forecasting predicts the next horizon for all channels of a multivariate series given a fixed look-back window. Recent work has explored very different inductive biases: pure linear projections after trend/seasonal decomposition (DLinear); channel-independent Transformer over patches (PatchTST); inverted attention treating variates as tokens (iTransformer); MLP-based multi-scale decomposition (TimeMixer); and explicit endogenous/exogenous separation (TimeXer). The Time-Series-Library protocol (Wu et al., ICLR 2023) standardizes splits, normalization, and metric computation so that architectural contributions can be compared head-to-head.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]` covering all target channels.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]` covering all target channels.
 
 ## Model Interface
 ```python

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/instruction.md
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/instruction.md
@@ -9,7 +9,7 @@ Can one univariate forecasting component (seasonal decomposition, scale normaliz
 Short, univariate, many-series forecasting is a well-studied problem dominated by combinations of statistical and ML methods. The Time-Series-Library (Wu et al., ICLR 2023) provides a standardized training and evaluation protocol with per-pattern fixed look-back / horizon settings and a SMAPE training loss.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]`; for the univariate setting `enc_in == c_out == 1`.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]`; for the univariate setting `enc_in == c_out == 1`.
 
 ## Model Interface
 ```python

--- a/tasks/ai4sci-inverse-diffusion-algo/task_description.md
+++ b/tasks/ai4sci-inverse-diffusion-algo/task_description.md
@@ -11,7 +11,7 @@ Diffusion models learn rich priors `p(x)` over signal distributions. For inverse
 - **LGD — Loss-Guided Diffusion** (Song et al., "Loss-Guided Diffusion Models for Plug-and-Play Controllable Generation", ICML 2023). Estimates the guidance term via Monte Carlo sampling around the denoised estimate to reduce bias of point-estimate approximations.
 
 ## What to Implement
-Implement the `Custom` class in `algo/custom.py`. You must implement:
+Implement the `Custom` class in `InverseBench/algo/custom.py`. You must implement:
 1. `__init__`: Set up your algorithm (schedulers, optimizers, hyperparameters).
 2. `inference(observation, num_samples)`: Given observation `y`, return reconstructed `x`.
 
@@ -34,4 +34,4 @@ The algorithm is tested on three scientific inverse problems:
 Higher PSNR/SSIM is better; lower LPIPS and chi-squared are better.
 
 ## Editable Region
-The entire `algo/custom.py` file is editable. You may define any helper classes/functions within this file.
+The entire `InverseBench/algo/custom.py` file is editable. You may define any helper classes/functions within this file.

--- a/tasks/causal-discovery-discrete/task_description.md
+++ b/tasks/causal-discovery-discrete/task_description.md
@@ -20,7 +20,7 @@ sizes (small to >70 nodes), and edge densities, without over-specializing to a
 single scale or cardinality pattern.
 
 ## Task
-Implement a causal discovery algorithm in `bench/custom_algorithm.py`. The
+Implement a causal discovery algorithm in `causal-bnlearn/bench/custom_algorithm.py`. The
 `run_causal_discovery(X)` function receives integer-encoded discrete
 observational data and must return the estimated CPDAG as a
 `causallearn.graph.GeneralGraph.GeneralGraph` object.

--- a/tasks/causal-observational-linear-gaussian/task_description.md
+++ b/tasks/causal-observational-linear-gaussian/task_description.md
@@ -13,7 +13,7 @@ robustness across sparse and denser graphs and across noise levels, and the
 method should not rely on dataset-specific constants.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a `causallearn.graph.GeneralGraph.GeneralGraph` representing the
 estimated CPDAG.
 

--- a/tasks/causal-observational-linear-non-gaussian/task_description.md
+++ b/tasks/causal-observational-linear-non-gaussian/task_description.md
@@ -19,7 +19,7 @@ moderate-to-large node counts and avoid assuming a single fixed noise
 distribution or graph family.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a directed DAG (skeleton + correct edge orientation) compatible with the
 benchmark evaluation.
 

--- a/tasks/causal-observational-nonlinear/task_description.md
+++ b/tasks/causal-observational-nonlinear/task_description.md
@@ -20,7 +20,7 @@ types (MLP, GP, polynomial, sigmoid), and (4) robustness when noise is
 Gaussian, where ANM identifiability becomes more delicate.
 
 ## Task
-Implement `run_causal_discovery(X)` in `bench/custom_algorithm.py`. It must
+Implement `run_causal_discovery(X)` in `causal-learn/bench/custom_algorithm.py`. It must
 return a directed DAG compatible with the benchmark evaluation.
 
 ## Evaluation Scenarios

--- a/tasks/cv-dbm-sampler/task_description.md
+++ b/tasks/cv-dbm-sampler/task_description.md
@@ -7,7 +7,7 @@ conditional generation quality on image-to-image translation tasks under a
 strict per-sample budget on the number of denoiser calls.
 
 Implement the algorithm inside the `sample_custom_bridge` function in
-`ddbm/karras_diffusion.py`. The evaluation pipeline calls this function to
+`dbim-codebase/ddbm/karras_diffusion.py`. The evaluation pipeline calls this function to
 generate target images from source conditions.
 
 ## Background

--- a/tasks/pde-design-solver/task_description.md
+++ b/tasks/pde-design-solver/task_description.md
@@ -1,7 +1,7 @@
 # Industrial CFD Design: Custom Neural Operator Design
 
 ## Objective
-Design and implement a custom neural operator for industrial aerodynamic design prediction on 3D unstructured point clouds. Your code goes in the `Model` class in `models/Custom.py`. Reference implementations (PointNet, GraphSAGE, Graph_UNet, Transolver) from Neural-Solver-Library are provided as read-only context.
+Design and implement a custom neural operator for industrial aerodynamic design prediction on 3D unstructured point clouds. Your code goes in the `Model` class in `Neural-Solver-Library/models/Custom.py`. Reference implementations (PointNet, GraphSAGE, Graph_UNet, Transolver) from Neural-Solver-Library are provided as read-only context.
 
 ## Background
 The task evaluates point-cloud / mesh-based neural operators on three steady aerodynamic design benchmarks. Key reference architectures:
@@ -29,7 +29,7 @@ forward(self, x, fx, T=None, geo=None) -> output
 Key `args` attributes: `n_hidden`, `n_layers`, `n_heads`, `space_dim` (2 for AirfRANS, 3 for Car/AirCraft), `fun_dim=7`, `out_dim` (4 for Car/AirfRANS, 6 for AirCraft), `act`, `mlp_ratio`, `dropout`, `geotype` (`unstructured`), `radius` (for graph construction), `slice_num` (for Transolver-style physics attention).
 
 ## Hyperparameter Override (`CONFIG_OVERRIDES`)
-The shell scripts (`scripts/car.sh`, `scripts/airfrans.sh`, `scripts/aircraft.sh`) default to `--n_hidden 128 --slice_num 32`. Different model families need different widths to be competitive — for example Transolver uses 256 in the original paper, while PointNet and Graph_UNet typically use much smaller widths. To set per-method values, edit the `CONFIG_OVERRIDES` dict at the bottom of `models/Custom.py`:
+The shell scripts (`scripts/car.sh`, `scripts/airfrans.sh`, `scripts/aircraft.sh`) default to `--n_hidden 128 --slice_num 32`. Different model families need different widths to be competitive — for example Transolver uses 256 in the original paper, while PointNet and Graph_UNet typically use much smaller widths. To set per-method values, edit the `CONFIG_OVERRIDES` dict at the bottom of `Neural-Solver-Library/models/Custom.py`:
 
 ```python
 # Allowed keys: n_hidden (int), slice_num (int).

--- a/tasks/security-adversarial-attack-black-box-score/task_description.md
+++ b/tasks/security-adversarial-attack-black-box-score/task_description.md
@@ -9,7 +9,7 @@ Score-based query black-box attacks assume the attacker can query the victim mod
 Representative algorithms include the random-search-based Square Attack (Andriushchenko et al., 2020, arXiv:1912.00049), gradient-free SPSA-based attacks (Uesato et al., 2018, arXiv:1802.05666), and pixel-coordinate random search baselines. Across these methods the central tradeoff is between per-step exploration (which helps escape local minima) and per-step exploitation (which keeps the query budget low).
 
 ## Objective
-Implement a better black-box attack in `bench/custom_attack.py`:
+Implement a better black-box attack in `torchattacks/bench/custom_attack.py`:
 
 - Threat model: query black-box (no gradient access, only model logits).
 - Constraint: `||x_adv - x||_inf <= eps`.

--- a/tasks/security-adversarial-attack-sparse-l0/task_description.md
+++ b/tasks/security-adversarial-attack-sparse-l0/task_description.md
@@ -9,7 +9,7 @@ Sparse adversarial attacks differ from dense `L_p` attacks in that the perturbat
 Representative sparse-attack algorithms include the Jacobian Saliency Map Attack JSMA (Papernot et al., 2016, arXiv:1511.07528), the differential-evolution One-Pixel attack (Su et al., 2019, arXiv:1710.08864), the geometry-inspired SparseFool (Modas et al., CVPR 2019, arXiv:1811.02248), the random-search Sparse-RS framework (Croce et al., AAAI 2022, arXiv:2006.12834), and Pixle, a fast pixel-rearrangement black-box attack (Pomponi et al., 2022, arXiv:2202.02236).
 
 ## Objective
-Implement a stronger sparse attack in `bench/custom_attack.py`. The method should maximize attack success rate (ASR) under a strict `L0` perturbation budget:
+Implement a stronger sparse attack in `torchattacks/bench/custom_attack.py`. The method should maximize attack success rate (ASR) under a strict `L0` perturbation budget:
 
 - Threat model: full model access for custom attack implementation (gradients permitted).
 - Norm constraint: number of modified spatial pixels is bounded.

--- a/tasks/security-adversarial-attack-white-box-linf/task_description.md
+++ b/tasks/security-adversarial-attack-white-box-linf/task_description.md
@@ -7,7 +7,7 @@ Can you design a stronger white-box `L_inf` evasion attack that increases attack
 White-box evasion attacks assume the attacker has full access to the model, including its parameters and gradients. The classical first-order attack is FGSM (Goodfellow et al., 2015, arXiv:1412.6572), a one-step sign-of-gradient attack. Iterative variants such as PGD (Madry et al., 2018, arXiv:1706.06083) and momentum iterative FGSM, MI-FGSM (Dong et al., CVPR 2018, arXiv:1710.06081), refine the perturbation through multiple gradient steps. AutoAttack (Croce and Hein, ICML 2020, arXiv:2003.01690) is a parameter-free ensemble of two adaptive PGD variants together with FAB and Square Attack and is widely used as a strong reference attack.
 
 ## Objective
-Implement a stronger white-box `L_inf` attack in `bench/custom_attack.py`. The method should maximize ASR under a strict perturbation budget:
+Implement a stronger white-box `L_inf` attack in `torchattacks/bench/custom_attack.py`. The method should maximize ASR under a strict perturbation budget:
 
 - Threat model: white-box (full model access, including gradients).
 - Norm constraint: `||x_adv - x||_inf <= eps`.

--- a/tasks/security-adversarial-training/task_description.md
+++ b/tasks/security-adversarial-training/task_description.md
@@ -7,7 +7,7 @@ How can we design better adversarial training methods to enhance model robustnes
 Adversarial training is the most effective approach for improving neural-network robustness against adversarial examples. The standard method (Madry et al., 2018, arXiv:1706.06083) trains on PGD-generated adversarial examples using cross-entropy loss but suffers from a tradeoff between clean accuracy and robust accuracy. Advanced methods such as TRADES (Zhang et al., ICML 2019, arXiv:1901.08573) and MART (Wang et al., ICLR 2020, OpenReview rklOg6EFwS) address this through different loss formulations that decouple the robustness objective from clean classification. AWP (Wu, Xia, Wang, NeurIPS 2020, arXiv:2004.05884) further regularizes the flatness of the weight loss landscape and combines naturally with TRADES-style training.
 
 ## Task
-Implement a novel adversarial training method in `bench/custom_adv_train.py` by modifying the `AdversarialTrainer` class. Your method should improve robust accuracy against white-box `L_inf` attacks while maintaining reasonable clean accuracy.
+Implement a novel adversarial training method in `torchattacks/bench/custom_adv_train.py` by modifying the `AdversarialTrainer` class. Your method should improve robust accuracy against white-box `L_inf` attacks while maintaining reasonable clean accuracy.
 
 ## Editable Interface
 You must implement the `AdversarialTrainer` class with two methods:

--- a/tasks/security-backdoor-defense/task_description.md
+++ b/tasks/security-backdoor-defense/task_description.md
@@ -7,7 +7,7 @@ How can we design a better poisoned-sample scoring rule that identifies backdoor
 Backdoor attacks (BadNets: Gu, Dolan-Gavitt, Garg, 2017, arXiv:1708.06733; Blended attack: Chen et al., 2017, arXiv:1712.05526) implant a trigger pattern into a subset of training examples and relabel them to an attacker-chosen target class. Models trained on this data retain high clean accuracy while also predicting the target label whenever the trigger appears. Many defenses try to identify suspicious points using feature statistics (Spectral Signatures: Tran, Li, Madry, NeurIPS 2018, arXiv:1811.00636), confidence patterns, or clustering structure (Activation Clustering: Chen et al., 2018, arXiv:1811.03728) before retraining on the filtered set, while pruning-style defenses (Fine-Pruning: Liu, Dolan-Gavitt, Garg, 2018, arXiv:1805.12185) operate on activations of suspicious neurons.
 
 ## Task
-Implement a stronger backdoor defense in `bench/backdoor/custom_backdoor_defense.py`. The fixed harness will:
+Implement a stronger backdoor defense in `pytorch-vision/bench/backdoor/custom_backdoor_defense.py`. The fixed harness will:
 
 1. Construct a poisoned training set for a fixed trigger pattern (full dataset, no subsampling).
 2. Train a victim model on the poisoned data for 100 epochs (SGD + CosineAnnealingLR).

--- a/tasks/security-machine-unlearning/task_description.md
+++ b/tasks/security-machine-unlearning/task_description.md
@@ -9,7 +9,7 @@ Machine unlearning methods approximate the effect of retraining without the dele
 The harness pretrains a standard vision model (ResNet-20, VGG-16-BN, or MobileNetV2) on the full training set for 80 epochs using SGD with cosine annealing. After pretraining, a single class is designated as the forget set. The unlearning method then runs for 20 epochs, receiving both retain-set and forget-set minibatches each step, with an Adam optimizer (`lr = 0.001`).
 
 ## Task
-Implement a better unlearning rule in `bench/unlearning/custom_unlearning.py`. The fixed harness trains an initial model, defines a forget split, and then applies your update rule for a fixed number of unlearning steps using retain and forget minibatches.
+Implement a better unlearning rule in `pytorch-vision/bench/unlearning/custom_unlearning.py`. The fixed harness trains an initial model, defines a forget split, and then applies your update rule for a fixed number of unlearning steps using retain and forget minibatches.
 
 Your method should lower forget-set memorization while preserving retained-task accuracy.
 

--- a/tasks/security-poison-robust-learning/task_description.md
+++ b/tasks/security-poison-robust-learning/task_description.md
@@ -9,7 +9,7 @@ A fraction of poisoned (label-flipped) training labels can disproportionately di
 This task uses research-scale models (ResNet-20, VGG-16-BN, MobileNetV2) trained on full datasets with standard SGD + CosineAnnealing for 100 epochs.
 
 ## Task
-Implement a better poison-robust objective in `bench/poison/custom_robust_loss.py`. The fixed harness injects random label-flip corruption (`(original + 1) % num_classes`) into the training set, trains with your loss, and evaluates on a clean test set.
+Implement a better poison-robust objective in `pytorch-vision/bench/poison/custom_robust_loss.py`. The fixed harness injects random label-flip corruption (`(original + 1) % num_classes`) into the training set, trains with your loss, and evaluates on a clean test set.
 
 Your method should improve clean test accuracy under poisoning while reducing how much the model memorizes poisoned labels. The approach must be modular and transferable across architectures and datasets.
 

--- a/tasks/ts-anomaly-detection/task_description.md
+++ b/tasks/ts-anomaly-detection/task_description.md
@@ -7,7 +7,7 @@ What modular reconstruction-based component (sequence representation, training o
 Reconstruction-based anomaly detection trains a model to reproduce normal input windows and flags points where the reconstruction error exceeds a threshold. The Time-Series-Library protocol (Wu et al., ICLR 2023) standardizes this setup: model outputs an MSE per timestep, the per-dataset `anomaly_ratio` percentile of train/test scores defines the threshold, and predictions are converted to point-wise binary labels for F1 / precision / recall scoring against ground-truth anomaly intervals.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a window `x_enc` of shape `[batch, seq_len, enc_in]`, return a reconstruction of the same shape. The framework computes the score, threshold, and metrics.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a window `x_enc` of shape `[batch, seq_len, enc_in]`, return a reconstruction of the same shape. The framework computes the score, threshold, and metrics.
 
 ## Model Interface
 ```python

--- a/tasks/ts-classification/task_description.md
+++ b/tasks/ts-classification/task_description.md
@@ -7,7 +7,7 @@ Can a single classification component (temporal encoder + channel-interaction + 
 The UEA Multivariate Time Series Classification archive (Bagnall et al., "The UEA multivariate time series classification archive, 2018", arXiv 1811.00075) is the standard benchmark for multivariate TSC. Datasets vary widely in sequence length, channel count, number of classes, sampling rate, and noise characteristics, making it a stress test for "general-purpose" temporal encoders. The Time-Series-Library protocol (Wu et al., ICLR 2023) standardizes train/test splits, padding to a common per-dataset length, RAdam optimization, cross-entropy loss, and accuracy reporting.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a padded input window plus a binary padding mask, return class logits.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a padded input window plus a binary padding mask, return class logits.
 
 ## Model Interface
 ```python

--- a/tasks/ts-exogenous-forecast/task_description.md
+++ b/tasks/ts-exogenous-forecast/task_description.md
@@ -7,7 +7,7 @@ What architectural component best fuses *exogenous* covariates (additional obser
 Many real-world forecasting tasks present a designated target variable accompanied by side-information channels (weather covariates for energy load, exogenous prices, related sensors). The Time-Series-Library `features=MS` mode formalizes this: all variables are fed into the model, but only the last channel (the target) is scored. Recent methods such as TimeXer (Wang et al., NeurIPS 2024) explicitly separate endogenous (patch-level) and exogenous (variate-level) representations and fuse them via cross-attention; iTransformer (Liu et al., ICLR 2024) treats every channel as a token and uses attention across channels; PatchTST (Nie et al., ICLR 2023) takes the channel-independent route and ignores cross-channel structure entirely. The contribution space here is the exogenous-fusion component itself.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]` where `c_out == enc_in`; the harness slices `outputs[:, :, -1:]` so only the final (target) channel is scored.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]` where `c_out == enc_in`; the harness slices `outputs[:, :, -1:]` so only the final (target) channel is scored.
 
 ## Model Interface
 ```python

--- a/tasks/ts-imputation/task_description.md
+++ b/tasks/ts-imputation/task_description.md
@@ -7,7 +7,7 @@ What modular imputation component (mask-aware temporal modeling, cross-channel d
 Time series imputation under random masking is a canonical "fill-in-the-blanks" benchmark for temporal models. The Time-Series-Library protocol (Wu et al., ICLR 2023) masks a fixed fraction of observed entries uniformly at random, hands the model both the masked sequence and a binary observation mask, and scores reconstruction error only at masked positions. This isolates the model's ability to infer missing values from surrounding temporal context and from correlated channels.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Given a partially-masked input window and a binary observation mask, return a fully reconstructed sequence; only positions where `mask == 0` count toward the metric.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Given a partially-masked input window and a binary observation mask, return a fully reconstructed sequence; only positions where `mask == 0` count toward the metric.
 
 ## Model Interface
 ```python

--- a/tasks/ts-long-term-forecast/task_description.md
+++ b/tasks/ts-long-term-forecast/task_description.md
@@ -7,7 +7,7 @@ What forecasting component (sequence modeling, decomposition, cross-variable att
 Long-term multivariate forecasting predicts the next horizon for all channels of a multivariate series given a fixed look-back window. Recent work has explored very different inductive biases: pure linear projections after trend/seasonal decomposition (DLinear); channel-independent Transformer over patches (PatchTST); inverted attention treating variates as tokens (iTransformer); MLP-based multi-scale decomposition (TimeMixer); and explicit endogenous/exogenous separation (TimeXer). The Time-Series-Library protocol (Wu et al., ICLR 2023) standardizes splits, normalization, and metric computation so that architectural contributions can be compared head-to-head.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]` covering all target channels.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]` covering all target channels.
 
 ## Model Interface
 ```python

--- a/tasks/ts-short-term-forecast/task_description.md
+++ b/tasks/ts-short-term-forecast/task_description.md
@@ -7,7 +7,7 @@ Can one univariate forecasting component (seasonal decomposition, scale normaliz
 The M4 competition (Makridakis, Spiliotis & Assimakopoulos, "The M4 Competition: 100,000 time series and 61 forecasting methods", *International Journal of Forecasting*, 2018/2020) collected 100,000 short, real-world series across 6 seasonal patterns (Yearly, Quarterly, Monthly, Weekly, Daily, Hourly). It is the standard benchmark for *short, univariate, many-series* forecasting and is dominated by combinations of statistical and ML methods. The Time-Series-Library protocol (Wu et al., ICLR 2023) wraps M4 with per-pattern fixed look-back / horizon settings, SMAPE training loss, and SMAPE / MAPE / OWA scoring.
 
 ## Objective
-Implement the `Model` class in `models/Custom.py`. Output shape is `[batch, pred_len, c_out]`; for the M4 univariate setting `enc_in == c_out == 1`.
+Implement the `Model` class in `Time-Series-Library/models/Custom.py`. Output shape is `[batch, pred_len, c_out]`; for the M4 univariate setting `enc_in == c_out == 1`.
 
 ## Model Interface
 ```python


### PR DESCRIPTION
## Make the editable-file path consistent with the edit contract (source + rendered)

### The problem
On a number of tasks the editable file is referred to by **two different paths**:

- The authoritative **"Files You May Edit"** section + **EDITABLE** code header,
  and the file's **real location**, use the package-**prefixed** path the edit
  contract is keyed on — e.g. `causal-learn/bench/custom_algorithm.py`.
- The natural-language **task body** named the same file by a package-**relative**
  path — e.g. `bench/custom_algorithm.py`.

An agent that follows the body edits a path that doesn't exist in its workspace
(the file is only at `causal-learn/bench/custom_algorithm.py`). The real edit
never lands, the pristine stub runs, and the task scores ~0 — with **no error
feedback** to signal the mistake. This is purely a path/doc inconsistency; the
evaluation logic, metrics, and editable line ranges are unchanged.

> Observed in the native harness (separate codebase): models that hit this first
> tried the package-relative path, were rejected, and **most recovered** by
> switching to the prefixed path (so historical scores looked fine) — but the
> friction wastes steps and **zeroes models that don't recover**. This PR removes
> the ambiguity at the source.

### The fix — both layers
Make the task body reference the editable file by the **same package-prefixed
path** as the edit contract. One-token change per occurrence; no prose, metric,
range, or eval change.

- **Source:** `tasks/<t>/task_description.md` (20 files) — this is what
  `instruction.md` is rendered from, so the fix survives a re-render.
- **Rendered:** `harbor/tasks/mls-bench__<t>/instruction.md` (20 files) — brought
  in line now so the shipped bundles are immediately consistent.

### Tasks (20)
- causal-discovery-discrete, causal-observational-linear-gaussian,
  causal-observational-linear-non-gaussian, causal-observational-nonlinear
- security-adversarial-attack-{black-box-score,sparse-l0,white-box-linf},
  security-adversarial-training, security-backdoor-defense,
  security-machine-unlearning, security-poison-robust-learning
- ts-{anomaly-detection,classification,exogenous-forecast,imputation,
  long-term-forecast,short-term-forecast}
- ai4sci-inverse-diffusion-algo, cv-dbm-sampler, pde-design-solver

After this change, **0** package-less editable-path references remain in the body
or instruction of any of these tasks, and body == "Files You May Edit" ==
EDITABLE header == real file path for every one. (`llm-on-policy-distillation`
has the same source bug but no rendered public bundle; it is fixed in the
benchmark dev repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
