### PR TITLE
fix(agent): accept package-relative edit paths in the native harness (mlsbench source)

### DIFF
--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-normalization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-regularization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-regularization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__graph-generation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__graph-generation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__jepa-planning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__jepa-planning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__mas-topology/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__mas-topology/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__meta-rl/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__meta-rl/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-calibration/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-calibration/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-nas/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-nas/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-parity/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-parity/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__safe-rl/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__safe-rl/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-classification/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-classification/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-imputation/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-imputation/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/mlsbench_src/mlsbench/agent/base.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/mlsbench_src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/mlsbench_src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state

--- a/src/mlsbench/agent/base.py
+++ b/src/mlsbench/agent/base.py
@@ -792,6 +792,12 @@ class BaseAgent(ABC):
         """Show edit operations as a git-style diff."""
         op = tool_input.get("op", "?")
         fname = tool_input.get("filename", "?")
+        # Mirror the edit tool: show the canonical (package-prefixed) path so the
+        # diff header matches the file actually edited.
+        try:
+            fname = self.tools._canonicalize_filename(fname)
+        except Exception:
+            pass
         content = tool_input.get("content", "")
         new_lines = content.splitlines()
         limit = None if self.verbose else 40

--- a/src/mlsbench/agent/tools.py
+++ b/src/mlsbench/agent/tools.py
@@ -615,6 +615,41 @@ class WorkspaceTools:
             f"Package '{pkg_name}' not found in workspace: {wtd}"
         )
 
+    def _canonicalize_filename(self, filename: str) -> str:
+        """Map a model-supplied path onto a declared file when the package
+        prefix is missing or wrong.
+
+        The task description and the diff headers refer to the target file by
+        its package-*relative* path (e.g. ``bench/custom_algorithm.py``), while
+        the edit whitelist keys on the package-*prefixed* path declared in
+        ``config.json`` (e.g. ``causal-learn/bench/custom_algorithm.py``). A
+        model that follows the prompt body would otherwise have every edit
+        rejected with "Package 'bench' is not in allowed packages" and score 0
+        without ever editing. Accept the package-less / basename form whenever it
+        unambiguously identifies one declared file; otherwise leave it unchanged
+        so the normal validation (and its error message) still applies.
+        """
+        if not filename:
+            return filename
+        first = filename.split("/")[0]
+        known = {self._normalize_pkg_name(p) for p in self.all_external_packages}
+        # Already a valid package-prefixed path → nothing to do.
+        if self._normalize_pkg_name(first) in known:
+            return filename
+        declared = [e["filename"] for e in self.config_edit]
+        norm = filename.strip("/")
+        # 1) Unique suffix match (most specific): declared endswith "/<supplied>".
+        suffix = [d for d in declared if d == norm or d.endswith("/" + norm)]
+        if len(suffix) == 1:
+            return suffix[0]
+        # 2) Unique basename match (e.g. just "custom_algorithm.py").
+        base = norm.rsplit("/", 1)[-1]
+        bmatch = [d for d in declared if d.rsplit("/", 1)[-1] == base]
+        if len(bmatch) == 1:
+            return bmatch[0]
+        return filename
+
+
     def _resolve_workspace_path(self, filename: str) -> Path:
         """Resolve a filename to an absolute path.
 
@@ -894,6 +929,11 @@ class WorkspaceTools:
         end_line: int | None = None,
     ) -> str:
         """Unified file editing tool."""
+        # Accept package-relative / basename paths (as written in the task body
+        # and diff headers) by mapping them onto the declared package-prefixed
+        # file before validation, so a correct edit isn't rejected on a prefix
+        # mismatch.
+        filename = self._canonicalize_filename(filename)
         result = self._edit_impl(op, filename, content, after_line, start_line, end_line)
 
         # Always append the current file snapshot so the model sees the live state


### PR DESCRIPTION
## Port the edit-path canonicalization into the public mlsbench source

Follow-up to #55 (which fixed the *documentation* path inconsistency). This
fixes the **native harness** side: anyone running `mlsbench agent <task>` from
this repo hit the same bug — the edit tool keyed its package whitelist on
`filename.split("/")[0]`, so an edit to the package-relative path the task body
names (e.g. `bench/custom_algorithm.py`) was rejected ("Package 'bench' is not
in allowed packages"), the model never edited, and the task scored 0 regardless
of capability (causal-*, security-*, ts-*, …).

### Fix
`WorkspaceTools._canonicalize_filename()` maps a package-less / basename path
onto the **unique** declared editable file before validation. It is a no-op when
the path is already a valid package path or the match is ambiguous, so working
tasks are unaffected. `BaseAgent._log_edit_diff` canonicalizes the same way so
the diff header matches the file actually edited.

### Why so many files
mlsbench source lives in **141 places** in this repo: top-level `src/mlsbench/`
plus a vendored snapshot in every bundle (`harbor/tasks/mls-bench__*/tests/
mlsbench_src/`). All 141 copies of `tools.py` (and of `base.py`) were
byte-identical before this change and remain byte-identical after — the fix is
applied uniformly so no copy drifts. Only `agent/tools.py` and `agent/base.py`
are touched; every patched file compiles and contains the new method.

No behavioral change for any honest edit; this only stops a correct edit from
being rejected purely on a missing package prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
