### PR TITLE
fix(humanoid-gym): torch 2.1.2+cu118 + restore TF32 for sm_90 (issue #47)

### DIFF
--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/pristine_manifest.json
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/pristine_manifest.json
@@ -7,7 +7,7 @@
   "humanoid-gym/humanoid/algo/ppo/__init__.py": "d248ffc04fc798a02761f9133b067d43e2cf25977c5b731c2560d6aa99e3b19f",
   "humanoid-gym/humanoid/algo/ppo/actor_critic.py": "48294aeb4178df7331afddd1c51c2cef34fa912b23c8e2f8c99543d76341fc1e",
   "humanoid-gym/humanoid/algo/ppo/actor_critic_custom.py": "3bf3f3dda6dea80ca7d0611f3695d34bd428e65e3e1d6218b9c6f66bc2069fd8",
-  "humanoid-gym/humanoid/algo/ppo/on_policy_runner.py": "07092622c8a818c2cc86310cb12928501072d87a9ccf019c9e05fd1dc75c2e9b",
+  "humanoid-gym/humanoid/algo/ppo/on_policy_runner.py": "5f87e140151399078659aa65924afa21eaa27e6c5101728292f7176cfd928b9b",
   "humanoid-gym/humanoid/algo/ppo/ppo.py": "c5f0a9047bf740e0ee73253d42a66dbf507dd672f35ab43616c75e126442875f",
   "humanoid-gym/humanoid/algo/ppo/ppo_custom.py": "c8009a26296c40520d0c17e344f0cbb84227753a173434fa6d53e0945685cf4e",
   "humanoid-gym/humanoid/algo/ppo/rollout_storage.py": "b1c677138532749c7f3372c126ea14bf602e13ff77b559190c2cd1869e477cf9",

--- a/vendor/pkg_configs/humanoid-gym/config.json
+++ b/vendor/pkg_configs/humanoid-gym/config.json
@@ -8,6 +8,8 @@
     "pip install mujoco==2.3.6 mujoco-python-viewer",
     "pip install wandb DateTime tensorboard tqdm matplotlib",
     "cd /workspace/humanoid-gym && pip install -e .",
+    "pip install --no-cache-dir torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu118",
+    "python -c \"import torch; print('torch', torch.__version__, 'cuda', torch.version.cuda); assert torch.__version__.startswith('2.1.2') and torch.version.cuda=='11.8', 'unexpected torch/cuda (need 2.1.2+cu118 for native sm_90)'\"",
     "pip uninstall -y opencv-python opencv-python-headless || true",
     "pip install --no-deps 'opencv-python-headless==4.5.5.64'"
   ],

--- a/vendor/pkg_configs/humanoid-gym/pre_edit.py
+++ b/vendor/pkg_configs/humanoid-gym/pre_edit.py
@@ -41,6 +41,27 @@ class _TBStub:
         return lambda *a, **kw: None
 import torch.utils.tensorboard as _tb
 _tb.SummaryWriter = _TBStub
+
+# --- TF32 matmul parity (sm_90 torch upgrade) ---------------------------------
+# The recorded anchor (sim2sim success 0.73) was trained under torch 1.12, whose
+# default is torch.backends.cuda.matmul.allow_tf32 == True: every fp32 nn.Linear
+# matmul in the actor/critic MLPs and PPO loss ran in TF32 (~10-bit mantissa).
+# torch >=2.x flips this default to False (full fp32, "highest" precision). With
+# identical CPU RNG and identical IsaacGym/obs eager numerics, this is the SOLE
+# diverging framework default between the two images, and it deterministically
+# shifts the optimization trajectory: the IsaacGym training reward still saturates
+# (~182) but the resulting policy generalizes worse in the MuJoCo sim2sim eval
+# (0.73 -> 0.20, same on seeds 42 and 123). Restore the torch-1.12 behavior so a
+# newer (sm_90-capable) torch reproduces the anchor.
+import torch as _torch
+try:
+    _torch.backends.cuda.matmul.allow_tf32 = True
+    _torch.backends.cudnn.allow_tf32 = True
+    if hasattr(_torch, "set_float32_matmul_precision"):
+        # "high" == TF32 for fp32 matmuls (matches torch 1.12 default behavior).
+        _torch.set_float32_matmul_precision("high")
+except Exception:
+    pass
 '''
 
 OPS = [


### PR DESCRIPTION
## Summary
Hardens the sm_90 (Hopper: H100/H20) execution path for `robo-humanoid-sim2real-algo` (issue #47) — at the **source** (so anyone rebuilding the image gets it) plus the rendered bundle and the prebuilt Docker Hub images.

## Source changes
1. **Pin `torch 2.1.2+cu118`** (`vendor/pkg_configs/humanoid-gym/config.json`). The base `nvcr.io/nvidia/pytorch:22.04` ships torch 1.12, whose cubins top out at sm_86 (+`compute_86` PTX) with no native Hopper kernel. On sm_90 it runs only via the driver's PTX→sm_90 JIT — slow on the first op and failing outright on nodes whose driver/JIT stack can't target sm_90 (the symptom in issue #47). `torch 2.1.2+cu118` (py3.8-compatible, kept for IsaacGym Preview 4) ships native sm_90 cubins, so no JIT is needed.
2. **Restore `allow_tf32=True`** (`vendor/pkg_configs/humanoid-gym/pre_edit.py`). torch ≥2.x flips this default to `False` (full fp32). The recorded sim2sim anchor (0.73) was trained under torch 1.12, where the default is `True`. That single flipped default deterministically shifts the PPO optimization trajectory (sim2sim 0.73 → 0.20, same on seeds 42 and 123), so it is restored to reproduce the anchor under the newer torch.

## Rendered change
- `harbor/.../tests/meta/pristine_manifest.json`: bump the hash for the **non-editable** `on_policy_runner.py` (its pre_edit'd content now carries the TF32 restore) to match the rebuilt `bohanlyu2022/mlsbench-harbor-humanoid-gym` base image, so the verifier's edit-range guard doesn't flag a phantom change to a protected file.

## Docker Hub images (rebuilt + re-pushed)
- `bohanlyu2022/mlsbench-humanoid-gym:latest` (native)
- `bohanlyu2022/mlsbench-harbor-humanoid-gym:latest` (harbor base; the per-task bundle `FROM`s this)

Both keep the stock IsaacGym Preview 4 `libPhysXGpu_64.so` (sha256 `2a475f57…`), which carries the `compute_86` PTX the driver JITs → sm_90 for GPU PhysX at `create_sim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
