### PR TITLE
fix(cv): respect assigned GPUs in diffusion training scripts

### DIFF
--- a/tasks/cv-diffusion-architecture/config.json
+++ b/tasks/cv-diffusion-architecture/config.json
@@ -7,7 +7,7 @@
       "cmd": "scripts/train_small.sh",
       "label": "train_small",
       "group": 1,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "1:30:00",
       "package": "diffusers-main"
     },
@@ -15,7 +15,7 @@
       "cmd": "scripts/train_medium.sh",
       "label": "train_medium",
       "group": 2,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "4:00:00",
       "package": "diffusers-main"
     },
@@ -23,7 +23,7 @@
       "cmd": "scripts/train_large.sh",
       "label": "train_large",
       "group": 3,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "10:00:00",
       "package": "diffusers-main",
       "hidden": true

--- a/tasks/cv-diffusion-architecture/scripts/train_large.sh
+++ b/tasks/cv-diffusion-architecture/scripts/train_large.sh
@@ -21,7 +21,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-architecture/scripts/train_medium.sh
+++ b/tasks/cv-diffusion-architecture/scripts/train_medium.sh
@@ -22,7 +22,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-architecture/scripts/train_small.sh
+++ b/tasks/cv-diffusion-architecture/scripts/train_small.sh
@@ -21,7 +21,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-conditioning/config.json
+++ b/tasks/cv-diffusion-conditioning/config.json
@@ -7,7 +7,7 @@
       "cmd": "scripts/train_small.sh",
       "label": "train_small",
       "group": 1,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "1:30:00",
       "package": "diffusers-main"
     },
@@ -15,7 +15,7 @@
       "cmd": "scripts/train_medium.sh",
       "label": "train_medium",
       "group": 2,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "4:00:00",
       "package": "diffusers-main"
     },
@@ -23,7 +23,7 @@
       "cmd": "scripts/train_large.sh",
       "label": "train_large",
       "group": 3,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "10:00:00",
       "package": "diffusers-main",
       "hidden": true

--- a/tasks/cv-diffusion-conditioning/scripts/train_large.sh
+++ b/tasks/cv-diffusion-conditioning/scripts/train_large.sh
@@ -22,7 +22,17 @@ export NUM_CLASSES=10
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-conditioning/scripts/train_medium.sh
+++ b/tasks/cv-diffusion-conditioning/scripts/train_medium.sh
@@ -21,7 +21,17 @@ export NUM_CLASSES=10
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-conditioning/scripts/train_small.sh
+++ b/tasks/cv-diffusion-conditioning/scripts/train_small.sh
@@ -22,7 +22,17 @@ export NUM_CLASSES=10
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-prediction/config.json
+++ b/tasks/cv-diffusion-prediction/config.json
@@ -7,7 +7,7 @@
       "cmd": "scripts/train_small.sh",
       "label": "train_small",
       "group": 1,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "1:30:00",
       "package": "diffusers-main"
     },
@@ -15,7 +15,7 @@
       "cmd": "scripts/train_medium.sh",
       "label": "train_medium",
       "group": 2,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "4:00:00",
       "package": "diffusers-main"
     },
@@ -23,7 +23,7 @@
       "cmd": "scripts/train_large.sh",
       "label": "train_large",
       "group": 3,
-      "compute": 1.0,
+      "compute": 8.0,
       "time": "10:00:00",
       "package": "diffusers-main",
       "hidden": true

--- a/tasks/cv-diffusion-prediction/scripts/train_large.sh
+++ b/tasks/cv-diffusion-prediction/scripts/train_large.sh
@@ -21,7 +21,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-prediction/scripts/train_medium.sh
+++ b/tasks/cv-diffusion-prediction/scripts/train_medium.sh
@@ -20,7 +20,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else

--- a/tasks/cv-diffusion-prediction/scripts/train_small.sh
+++ b/tasks/cv-diffusion-prediction/scripts/train_small.sh
@@ -21,7 +21,17 @@ export NUM_FID_SAMPLES=50000
 export DIFFUSION_STEPS=1000
 export SAMPLE_STEPS=50
 
-NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+if [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "${CUDA_VISIBLE_DEVICES}" != "NoDevFiles" ]; then
+    IFS=',' read -ra _MLSBENCH_GPUS <<< "$CUDA_VISIBLE_DEVICES"
+    NGPU=0
+    for _gpu in "${_MLSBENCH_GPUS[@]}"; do
+        if [ -n "$_gpu" ]; then
+            NGPU=$((NGPU + 1))
+        fi
+    done
+else
+    NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+fi
 if [ "$NGPU" -gt 1 ]; then
     torchrun --nproc_per_node="$NGPU" --master_port=29500 custom_train.py
 else


### PR DESCRIPTION
## Summary
- Set the three CV diffusion training tasks to request 8 GPUs per train command so their documented 8-GPU DDP setup runs by default.
- Count GPUs from CUDA_VISIBLE_DEVICES before falling back to nvidia-smi in the corresponding training scripts.
- This keeps torchrun nproc_per_node aligned with the GPUs assigned by MLS-Bench schedulers, giving BATCH_SIZE=128 per rank and global batch size 1024 on 8 GPUs.

## Files changed
- tasks/cv-diffusion-architecture/config.json
- tasks/cv-diffusion-conditioning/config.json
- tasks/cv-diffusion-prediction/config.json
- tasks/cv-diffusion-architecture/scripts/train_{small,medium,large}.sh
- tasks/cv-diffusion-conditioning/scripts/train_{small,medium,large}.sh
- tasks/cv-diffusion-prediction/scripts/train_{small,medium,large}.sh

## Validation
- Parsed the three modified config.json files and confirmed all train commands use compute=8.0.
- bash -n on all nine modified training scripts.