### PR TITLE
fix(cv-dbm-scheduler): harden FID parsing + dataset-scope fid.json lookup (native + Harbor)

### DIFF
--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/meta/parser.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/meta/parser.py
@@ -17,11 +17,16 @@ class Parser(OutputParser):
         # "[\d.]+" matched the integer "0" from that progress bar instead of the
         # real "FID: 5.55" result line, zeroing best_fid_Imagenet. tqdm
         # percentages are integers; the real FID is always fractional, so
-        # \d+\.\d+ skips the bar and matches the result line.
-        _fid_vals = re.findall(r"FID(?:\s*score)?:\s*(\d+\.\d+)", raw_output, re.IGNORECASE)
+        # \d+\.\d+ skips the bar and matches the result line (an optional
+        # exponent tolerates scientific notation).
+        _fid_vals = re.findall(
+            r"FID(?:\s*score)?:\s*(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output, re.IGNORECASE
+        )
         # Also match dict format: {'fid': np.float64(<number>), ...}
         if not _fid_vals:
-            _fid_vals = re.findall(r"'fid':\s*(?:np\.float64\()?(\d+\.\d+)", raw_output)
+            _fid_vals = re.findall(
+                r"'fid':\s*(?:np\.float64\()?(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output
+            )
         fid_str = _fid_vals[-1] if _fid_vals else None
         
         # NFE budget enforcement: reject if the karras_sample wrapper reports

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
@@ -17,8 +17,15 @@ mkdir -p "$sample_dir"
 bash scripts/sample.sh $ds $nfe $sampler $eta
 # FID computed first (streaming get_fid); tolerate the paired-LPIPS crash that
 # follows on N-mismatch and surface FID from wherever fid.json landed.
+# Scope fid.json to THIS dataset's trees ("*${ds}*" matches the model-prefix
+# dirs e2h_*/diode_* and $sample_dir): all three settings share workdir/ and
+# run concurrently in the same group, so an unscoped `find | head -1` could
+# surface another dataset's fid.json (DIODE echoing edges2handbags' FID).
+# Pre-delete this dataset's stale fid.json so a crashed eval behind `|| true`
+# can't re-echo a previous iteration's value.
+find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json -delete 2>/dev/null || true
 bash scripts/evaluate.sh $ds $nfe $sampler $eta || true
-FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -name fid.json 2>/dev/null | head -1)
+FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json 2>/dev/null | head -1)
 if [ -n "$FID_JSON" ]; then
     echo "FID: $(python3 -c "import json; print(json.load(open('$FID_JSON'))['fid'])")"
 fi

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_e2h.sh
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_e2h.sh
@@ -21,8 +21,15 @@ bash scripts/sample.sh $ds $nfe $sampler $eta
 # have equal N and core-dumps when they differ (it does here). FID is the only
 # scored metric, so tolerate the LPIPS crash and surface FID from wherever
 # get_fid wrote fid.json.
+# Scope fid.json to THIS dataset's trees ("*${ds}*" matches the model-prefix
+# dirs e2h_*/diode_* and $sample_dir): all three settings share workdir/ and
+# run concurrently in the same group, so an unscoped `find | head -1` could
+# surface another dataset's fid.json (DIODE echoing edges2handbags' FID).
+# Pre-delete this dataset's stale fid.json so a crashed eval behind `|| true`
+# can't re-echo a previous iteration's value.
+find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json -delete 2>/dev/null || true
 bash scripts/evaluate.sh $ds $nfe $sampler $eta || true
-FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -name fid.json 2>/dev/null | head -1)
+FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json 2>/dev/null | head -1)
 if [ -n "$FID_JSON" ]; then
     echo "FID: $(python3 -c "import json; print(json.load(open('$FID_JSON'))['fid'])")"
 fi

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/parser.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/parser.py
@@ -10,9 +10,22 @@ class Parser(OutputParser):
     def parse(self, cmd_label: str, raw_output: str) -> ParseResult:
         metrics = {}
         feedback = ""
-        fid_match = re.search(r"FID(?:\s*score)?:\s*([\d.]+)", raw_output, re.IGNORECASE)
-        if fid_match:
-            fid_val = float(fid_match.group(1))
+        # Require a decimal point and take the LAST match: when FID reference
+        # statistics are generated on the fly, the inception feature loop prints a
+        # tqdm bar "FID:   0%|..." whose integer "0" a greedy "[\d.]+" would match
+        # instead of the real "FID: 5.55" result line (zeroing best_fid). tqdm
+        # percentages are integers; the real FID is fractional, so \d+\.\d+ skips
+        # the bar (an optional exponent tolerates scientific notation). Mirrors
+        # the fix in tasks/cv-dbm-sampler/parser.py.
+        _fid_vals = re.findall(
+            r"FID(?:\s*score)?:\s*(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output, re.IGNORECASE
+        )
+        if not _fid_vals:
+            _fid_vals = re.findall(
+                r"'fid':\s*(?:np\.float64\()?(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output
+            )
+        if _fid_vals:
+            fid_val = float(_fid_vals[-1])
             label = cmd_label.replace("-", "_")
             metrics["fid"] = fid_val
             metrics["best_fid"] = fid_val

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
@@ -17,8 +17,15 @@ mkdir -p "$sample_dir"
 bash scripts/sample.sh $ds $nfe $sampler $eta
 # FID computed first (streaming get_fid); tolerate the paired-LPIPS crash that
 # follows on N-mismatch and surface FID from wherever fid.json landed.
+# Scope fid.json to THIS dataset's trees ("*${ds}*" matches the model-prefix
+# dirs e2h_*/diode_* and $sample_dir): all three settings share workdir/ and
+# run concurrently in the same group, so an unscoped `find | head -1` could
+# surface another dataset's fid.json (DIODE echoing edges2handbags' FID).
+# Pre-delete this dataset's stale fid.json so a crashed eval behind `|| true`
+# can't re-echo a previous iteration's value.
+find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json -delete 2>/dev/null || true
 bash scripts/evaluate.sh $ds $nfe $sampler $eta || true
-FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -name fid.json 2>/dev/null | head -1)
+FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json 2>/dev/null | head -1)
 if [ -n "$FID_JSON" ]; then
     echo "FID: $(python3 -c "import json; print(json.load(open('$FID_JSON'))['fid'])")"
 fi

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_e2h.sh
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_e2h.sh
@@ -21,8 +21,15 @@ bash scripts/sample.sh $ds $nfe $sampler $eta
 # have equal N and core-dumps when they differ (it does here). FID is the only
 # scored metric, so tolerate the LPIPS crash and surface FID from wherever
 # get_fid wrote fid.json.
+# Scope fid.json to THIS dataset's trees ("*${ds}*" matches the model-prefix
+# dirs e2h_*/diode_* and $sample_dir): all three settings share workdir/ and
+# run concurrently in the same group, so an unscoped `find | head -1` could
+# surface another dataset's fid.json (DIODE echoing edges2handbags' FID).
+# Pre-delete this dataset's stale fid.json so a crashed eval behind `|| true`
+# can't re-echo a previous iteration's value.
+find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json -delete 2>/dev/null || true
 bash scripts/evaluate.sh $ds $nfe $sampler $eta || true
-FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -name fid.json 2>/dev/null | head -1)
+FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -ipath "*${ds}*" -name fid.json 2>/dev/null | head -1)
 if [ -n "$FID_JSON" ]; then
     echo "FID: $(python3 -c "import json; print(json.load(open('$FID_JSON'))['fid'])")"
 fi

--- a/tasks/cv-dbm-sampler/parser.py
+++ b/tasks/cv-dbm-sampler/parser.py
@@ -17,11 +17,16 @@ class Parser(OutputParser):
         # "[\d.]+" matched the integer "0" from that progress bar instead of the
         # real "FID: 5.55" result line, zeroing best_fid_Imagenet. tqdm
         # percentages are integers; the real FID is always fractional, so
-        # \d+\.\d+ skips the bar and matches the result line.
-        _fid_vals = re.findall(r"FID(?:\s*score)?:\s*(\d+\.\d+)", raw_output, re.IGNORECASE)
+        # \d+\.\d+ skips the bar and matches the result line (an optional
+        # exponent tolerates scientific notation).
+        _fid_vals = re.findall(
+            r"FID(?:\s*score)?:\s*(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output, re.IGNORECASE
+        )
         # Also match dict format: {'fid': np.float64(<number>), ...}
         if not _fid_vals:
-            _fid_vals = re.findall(r"'fid':\s*(?:np\.float64\()?(\d+\.\d+)", raw_output)
+            _fid_vals = re.findall(
+                r"'fid':\s*(?:np\.float64\()?(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output
+            )
         fid_str = _fid_vals[-1] if _fid_vals else None
         
         # NFE budget enforcement: reject if the karras_sample wrapper reports

--- a/tasks/cv-dbm-scheduler/parser.py
+++ b/tasks/cv-dbm-scheduler/parser.py
@@ -10,9 +10,22 @@ class Parser(OutputParser):
     def parse(self, cmd_label: str, raw_output: str) -> ParseResult:
         metrics = {}
         feedback = ""
-        fid_match = re.search(r"FID(?:\s*score)?:\s*([\d.]+)", raw_output, re.IGNORECASE)
-        if fid_match:
-            fid_val = float(fid_match.group(1))
+        # Require a decimal point and take the LAST match: when FID reference
+        # statistics are generated on the fly, the inception feature loop prints a
+        # tqdm bar "FID:   0%|..." whose integer "0" a greedy "[\d.]+" would match
+        # instead of the real "FID: 5.55" result line (zeroing best_fid). tqdm
+        # percentages are integers; the real FID is fractional, so \d+\.\d+ skips
+        # the bar (an optional exponent tolerates scientific notation). Mirrors
+        # the fix in tasks/cv-dbm-sampler/parser.py.
+        _fid_vals = re.findall(
+            r"FID(?:\s*score)?:\s*(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output, re.IGNORECASE
+        )
+        if not _fid_vals:
+            _fid_vals = re.findall(
+                r"'fid':\s*(?:np\.float64\()?(\d+\.\d+(?:[eE][+-]?\d+)?)", raw_output
+            )
+        if _fid_vals:
+            fid_val = float(_fid_vals[-1])
             label = cmd_label.replace("-", "_")
             metrics["fid"] = fid_val
             metrics["best_fid"] = fid_val


### PR DESCRIPTION
## Problem

Two determinate scoring bugs in `cv-dbm-scheduler` corrupted the metrics of otherwise-clean runs (both reproduced bit-exactly from saved raw eval logs):

### 1. ImageNet tqdm `FID:   0%` parsed as FID = 0

`tests/meta/parser.py` (and the native `tasks/cv-dbm-scheduler/parser.py`) used:

```python
fid_match = re.search(r"FID(?:\s*score)?:\s*([\d.]+)", raw_output, re.IGNORECASE)
```

When FID reference statistics are computed on the fly, the inception feature loop prints a tqdm bar first:

```
FID:   0%|          | 0/98 ...
...
FID: 10.966330361939129
```

`re.search` takes the **first** match and `[\d.]+` happily accepts the integer `0` from the bar, so `best_fid_Imagenet` was recorded as 0 while the real FID sat further down the log. The sibling `cv-dbm-sampler` parser was already fixed for exactly this (`re.findall` + require a decimal + take the **last** match + evaluator-dict fallback), but the fix was never mirrored to the scheduler.

### 2. DIODE echoed edges2handbags' FID

The Harbor bundle's `run_e2h.sh` / `run_DIODE.sh` surfaced the FID with an **unscoped** lookup:

```bash
FID_JSON=$(find workdir "$sample_dir" "${OUTPUT_DIR:-output}" -name fid.json 2>/dev/null | head -1)
```

The three eval settings share one workspace and run concurrently in the same group. The patched `get_fid` writes `fid.json` next to the samples npz under the model-prefix dir (`workdir/e2h_ema_*/...`, `workdir/diode_ema_*/...`), and e2h's file survives its own cleanup — so when DIODE finished, `head -1` handed it edges2handbags' `fid.json` and the wrapper echoed the wrong FID as the last `FID:` line of DIODE's log (which the parser then took).

## Fix

- **Parser** (native `tasks/` + bundle `tests/meta/`, scheduler + sampler kept mirrored): `re.findall`, require a fractional value (skips integer tqdm percentages), take the last match, keep the `{'fid': np.float64(...)}` evaluator-dict fallback, and tolerate scientific notation.
- **Wrappers** (`tests/eval/scripts/` executed copy + `tests/meta/scripts/` mirror, e2h + DIODE): scope the lookup to this dataset's own trees via `-ipath "*${ds}*"` (the model-prefix dirs and `$sample_dir` embed the dataset name), and pre-delete the dataset's stale `fid.json` before `evaluate.sh` so a crashed eval behind `|| true` can't re-echo a previous iteration's value. `run_Imagenet.sh` needs no change: its `res.json` glob is already ImageNet-scoped and its eval isn't error-tolerated.

## Scope / verification

- Repo-wide sweep: the exact dangerous regex exists **only** in cv-dbm-scheduler (native + bundle meta); the unscoped `find ... -name fid.json | head -1` only in the scheduler bundle's four wrapper copies. `cv-dbm-sampler` already carries the fixed parser and dataset-explicit `fid.json` reads.
- Regression tests added in the dev repo (`tests/test_cv_dbm_fid_parsing.py`, 9 tests, all passing) covering: tqdm-zero collision, last-match-wins, scientific notation, evaluator-dict fallback, per-label isolation across the three settings, NFE rejection, and — against this checkout's actual bundle scripts — dataset-scoped `fid.json` resolution with both datasets' files present, scoped stale pre-delete, and parser drift.
- Native leaderboards are clean (no zeroed FID rows); native runs never hit either bug (precomputed ref stats → no tqdm bar; no `fid.json` echo path).

## Follow-up for downstream result archives

Existing cv-dbm-scheduler results parsed from affected logs (fingerprint: `best_fid_Imagenet=0` and/or `best_fid_DIODE == best_fid_edges2handbags`) should be re-parsed/re-scored from the saved raw logs — with the true values the affected runs' rewards drop substantially (e.g. 0.7254 → 0.0825, 0.7746 → 0.3434 in the two known clean-artifact cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)