### PR TITLE
Fix false edit-guard failures for single ranges

### DIFF
--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor_adapter/tests/test_score_task.py
+++ b/harbor_adapter/tests/test_score_task.py
@@ -140,6 +140,27 @@ def test_edit_guard_rejects_deleted_fixed_separator_with_duplicate_in_editable(t
     assert "only the declared editable range" in reason
 
 
+def test_edit_guard_allows_single_range_replacement_with_repeated_suffix_line(tmp_path: Path):
+    """SequenceMatcher must not steal a repeated fixed suffix line.
+
+    The pristine editable line and fixed suffix are intentionally identical.
+    Replacing the editable line leaves the suffix byte-for-byte intact, but a
+    global diff aligns the suffix with the editable occurrence and reports the
+    actual suffix as deleted.
+    """
+    score_task = _load_score_task()
+    pristine = tmp_path / "pristine.py"
+    current = tmp_path / "current.py"
+
+    pristine.write_text("header\nrepeated\nrepeated\n")
+    current.write_text("header\nreplacement\nrepeated\n")
+
+    ranges = [score_task.EditRange(2, 2)]
+    ok, reason = score_task._check_editable_only(pristine, current, ranges)
+
+    assert ok, reason
+
+
 def test_edit_guard_rejects_protected_line_with_open_ended_tail_range(tmp_path: Path):
     """Regression: a disjoint range list whose last range uses end=-1 (to-EOF)
     must NOT mark the whole file editable for the line-level backstop. Here the


### PR DESCRIPTION
## Why

The verifier can reject a valid single-range edit when `SequenceMatcher` aligns a repeated boundary line inside the editable replacement and reports the unchanged fixed suffix as deleted.

## What changed

- Treat anchored pristine prefix and suffix equality as a complete proof for a single editable interval.
- Retain the line-level `SequenceMatcher` backstop for multiple disjoint ranges.
- Add a regression test with a repeated suffix line.

## Validation

- `uv run --no-project --with pytest python -m pytest harbor_adapter/tests/test_score_task.py -q -k edit_guard` (4 passed)