### PR TITLE
Align the Parameter Budget template with the shipped instructions

### DIFF
--- a/harbor_adapter/src/mls_bench/adapter.py
+++ b/harbor_adapter/src/mls_bench/adapter.py
@@ -884,14 +884,6 @@ def _has_budget_check(task_dir: Path) -> bool:
     return (task_dir / "budget_check.py").exists()
 
 
-def _budget_multiplier(task_dir: Path) -> float:
-    p = task_dir / "budget_check.py"
-    if not p.exists():
-        return 1.05
-    m = re.search(r"BUDGET_MULTIPLIER\s*=\s*([0-9.]+)", p.read_text())
-    return float(m.group(1)) if m else 1.05
-
-
 def render_task(
     mb: MlsBenchRoot,
     ctx: TaskContext,
@@ -944,7 +936,6 @@ def render_task(
         "extra_readable_files": _readable_only_files(effective_config),
         "visible_test_cmds": visible_test_cmds,
         "has_budget_check": _has_budget_check(task_dir),
-        "budget_multiplier": _budget_multiplier(task_dir),
         "baseline_name": ctx.chosen_baseline or "noop",
         "env_vars": ctx.pkg_config.get("env") or {},
         "data_deps": ctx.pkg_config.get("data_deps") or [],

--- a/harbor_adapter/src/mls_bench/task-template/instruction.md.j2
+++ b/harbor_adapter/src/mls_bench/task-template/instruction.md.j2
@@ -68,10 +68,7 @@ leaderboard. Multiple seeds are averaged.
 {% if has_budget_check -%}
 ## Parameter Budget
 
-This task enforces a parameter-count cap. Your edits will be rejected if
-the resulting model exceeds **{{ budget_multiplier }}×** the strongest
-baseline's parameter count. The check runs automatically inside the eval
-scripts — you don't need to invoke it.
+Your edits must not significantly increase the model's total parameter count relative to the strongest baseline. The check runs automatically — you don't need to invoke it — and a model over the cap makes the run invalid. Aim for an algorithmic contribution rather than added capacity.
 {%- endif %}
 
 {% if baseline_sections -%}


### PR DESCRIPTION
Companion to #70. That PR restored the parameter-cap notice to the 37 rendered tasks that had lost it and normalised the wording of the rest — all by hand-patching `instruction.md`, never re-rendering. This PR makes the template agree, so the next re-render does not overwrite it.

## Two problems with the old block

**1. It published the exact multiplier.**

```jinja
This task enforces a parameter-count cap. Your edits will be rejected if
the resulting model exceeds **{{ budget_multiplier }}×** the strongest
baseline's parameter count. ...
```

The native harness never states a number — `InteractiveAgent`'s system prompt only says *"parameter count is capped (enforced before each test)"*. So Harbor was strictly more explicit about the evaluation setting than the native run it mirrors.

**2. The multiplier was usually a guess.**

```python
m = re.search(r"BUDGET_MULTIPLIER\s*=\s*([0-9.]+)", p.read_text())
return float(m.group(1)) if m else 1.05
```

No `budget_check.py` in the repo defines `BUDGET_MULTIPLIER`, so this always returned the `1.05` fallback. Correct for 50 tasks, wrong for `meta-rl` (enforces 1.1x) and `meta-rl-algorithm` (1.2x) — both would have been rendered with a cap *tighter* than the one enforced, telling agents to leave headroom they actually had.

## Change

Drop the ratio, keep the constraint, delete the now-unused `_budget_multiplier()` helper and its context entry. The `has_budget_check` gate is untouched, so exactly the same set of tasks gets the section.

New wording, identical to what #70 ships:

> Your edits must not significantly increase the model's total parameter count relative to the strongest baseline. The check runs automatically — you don't need to invoke it — and a model over the cap makes the run invalid. Aim for an algorithmic contribution rather than added capacity.

Verified by rendering the fragment: output matches the hand-patched files byte-for-byte, including surrounding blank lines, so a re-render is a no-op on this section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)