### PR TITLE
Harbor verifier: ship the single-range guard fix (completes #69) and stop deleting agent-created files

### DIFF
--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__agent-tool-reasoning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-mutation-effect-prediction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-inverse-folding/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4bio-protein-structure-repr/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-climate-emulation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-inverse-diffusion-algo/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-mol-property-prediction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-pla-binding-affinity/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-vs-contrastive-scoring/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ai4sci-weather-forecast-aggregation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-discovery-discrete/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-gaussian/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-linear-non-gaussian/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-observational-nonlinear/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
+++ b/harbor/tasks/mls-bench__causal-treatment-effect/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-densification/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-3dgs-regularizer/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-classification-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-data-augmentation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-sampler/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-dbm-scheduler/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-architecture/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-cfg/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-conditioning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-efficiency/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-diffusion-prediction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-meanflow-perceptual-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-multitask-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-pooling-aggregation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-sample-weighting/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__cv-vae-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-activation-function/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-lr-schedule/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-normalization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-regularization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-residual-connection/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dl-weight-initialization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__dlm-dkv-policy/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-generation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-graph-classification/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-link-prediction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-node-classification/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__graph-signal-propagation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-planning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-prediction-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__jepa-regularizer/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-dllm-demask-strategy/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-adaptive-quantization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-selection-budgeting/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-kv-structural-reduction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-attention/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-bitlinear/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-embedding/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-kernel/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-linear-attention/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-lr-schedule/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-mlp/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-normalization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-optimizer/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-pretrain-residual/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-ptq-algorithm/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-qat-algorithm/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-advantage/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-importance-sampling/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-kl-estimator/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-rl-reward-normalization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
+++ b/harbor/tasks/mls-bench__llm-scaling-law-discovery/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
+++ b/harbor/tasks/mls-bench__marl-centralized-critic/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mas-topology/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-fewshot-classification/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-inner-loop-optimizer/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl-algorithm/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__meta-rl/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-active-learning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-anomaly-detection/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-calibration/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-clustering-algorithm/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-continual-regularization/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-dimensionality-reduction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-ensemble-boosting/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-federated-aggregation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-missing-data-imputation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-selective-deferral/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-subgroup-calibration-shift/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ml-symbolic-regression/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-fused-attention/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-moe-load-balance/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
+++ b/harbor/tasks/mls-bench__mlsys-sparse-attention-inference/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-bilevel/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-convex-concave/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-diagonal-net/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-dp-sgd/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-evolution-strategy/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-gradient-compression/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-hyperparameter-search/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-multi-objective/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-nas/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-online-bandit/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-pac-bayes-bound/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-parity/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__optimization-variance-reduction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
+++ b/harbor/tasks/mls-bench__pde-design-solver/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-concept-drift/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-graph-stock/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
+++ b/harbor/tasks/mls-bench__quant-stock-prediction/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-intrinsic-exploration/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-adroit/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-continuous/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offline-off2on/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-offpolicy-continuous/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-onpolicy-continuous/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-reward-learning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-atari/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
+++ b/harbor/tasks/mls-bench__rl-value-discrete/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-guidance/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-policy/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-bc-loss/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-iql-vf/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
+++ b/harbor/tasks/mls-bench__robomimic-obs-encoder/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
+++ b/harbor/tasks/mls-bench__safe-rl/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-black-box-score/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-sparse-l0/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-attack-white-box-linf/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-adversarial-training/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-backdoor-defense/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-machine-unlearning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-membership-inference-defense/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__security-poison-robust-learning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__stf-traffic-forecast/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-planning/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
+++ b/harbor/tasks/mls-bench__tdmpc2-simnorm/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-anomaly-detection/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-classification/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-exogenous-forecast/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-imputation/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-long-term-forecast/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
+++ b/harbor/tasks/mls-bench__ts-short-term-forecast/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor_adapter/README.md
+++ b/harbor_adapter/README.md
@@ -74,7 +74,12 @@ mls-bench__<task-id>/
   baseline edits that change line counts). Files under guarded prefixes but
   not declared are hash-checked against `pristine_manifest.json`. Violation
   → reward 0 + `/logs/verifier/violation.txt`.
-- **`allow_create: false`** — new files anywhere in workspace → reward 0.
+- **`allow_create`** — documents whether a task expects the agent to author new
+  files. The guard does not act on it: creating files is neither a violation nor
+  reverted. It protects the fixed baseline against *modification* and *deletion*,
+  which is what an agent cannot otherwise do. Note the asymmetry with the native
+  harness, where the agent has no shell and `edit(op="create")` is refused
+  outright when the flag is false.
 - **`budget_check.py`** (e.g. `llm-pretrain-normalization`) runs as part of
   the eval scripts; no extra wrapping needed.
 - **Hidden eval scripts** — all eval scripts (visible + hidden) live in

--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -87,8 +87,8 @@ def _check_editable_only(
     replacements that change the line count (e.g. a 7-line baseline stub
     swapped for a 30-line implementation).
 
-    If `pristine` doesn't exist, the agent created the file — caller decides
-    whether to allow that based on `allow_create`.
+    If `pristine` doesn't exist, the agent created the file; the caller does
+    not treat that as a violation.
     """
     if not pristine.exists():
         return False, "new file (no pristine)"
@@ -312,7 +312,6 @@ def cmd_guard(args: argparse.Namespace) -> int:
     violations: list[str] = []
 
     editable = _editable_files(config)
-    allow_create = bool(config.get("allow_create", False))
     # Optional per-task allowlist of workdir-relative prefixes dropped from the
     # guard — for image-baked data/build dirs inside the package dir that aren't
     # the agent's editable surface and were never in the render-time manifest
@@ -327,47 +326,30 @@ def cmd_guard(args: argparse.Namespace) -> int:
     guarded_prefixes = {Path(f).parts[0] for f in editable if f}
     guarded_prefixes |= {Path(f).parts[0] for f in manifest if f}
 
-    # Newly-created files (present in the workspace, absent from the render-time
-    # manifest) are NOT tampering. The anti-cheat surface this guard protects is
-    # *modification* or *deletion* of the fixed baseline (scorer/tests/data/model
-    # source) — handled below. A brand-new file is, at worst, agent scratch
-    # (an experiment script, a `*.bak`, a `test_*.py`); hard-failing the whole
-    # run for it (reward 0, eval never runs) zeroes otherwise-correct solutions.
-    # Instead, REMOVE such files before the eval so they cannot influence it
-    # (e.g. shadow-import a package module), then continue. A task that
-    # legitimately needs the agent to author new files sets allow_create=true.
+    # Newly-created files are neither a violation nor removed. The surface this
+    # guard protects is *modification* and *deletion* of the fixed baseline
+    # (scorer/tests/data/model source) — both handled below. Creation is left
+    # alone on purpose:
     #
-    # Only files under a guarded package prefix are cleaned — those are the only
-    # ones that can shadow-import a protected module; created files elsewhere are
-    # harmless and left untouched. Unlink uses the LITERAL workspace path, never
-    # _safe_join (which resolve()s symlinks): we must remove the created entry
-    # itself — never a symlink's *target* (which could be a manifest file) — and
-    # must not raise on a symlink that points outside the workspace.
-    cleaned_created: list[str] = []
-    failed_clean: list[str] = []
-    if not allow_create:
-        for rel in sorted(workspace_files):
-            rel_str = rel.as_posix()
-            if rel_str in manifest:
-                continue
-            if not rel.parts or rel.parts[0] not in guarded_prefixes:
-                continue
-            try:
-                (workspace_root / rel_str).unlink()
-                cleaned_created.append(rel_str)
-            except (OSError, ValueError):
-                failed_clean.append(rel_str)
-        if cleaned_created:
-            removed = set(cleaned_created)
-            workspace_files = {p for p in workspace_files
-                               if p.as_posix() not in removed}
-            workspace_rel_strs = {p.as_posix() for p in workspace_files}
-        if cleaned_created or failed_clean:
-            # Debug breadcrumb only — NOT a violation.
-            lines = cleaned_created + [f"{p}  [unlink-failed]" for p in failed_clean]
-            (violation_out.parent / "cleaned_created.txt").write_text(
-                "\n".join(lines) + "\n"
-            )
+    #   * Deleting them silently broke legitimate work. An agent that split its
+    #     implementation into a helper module and imported it from the editable
+    #     file got the helper unlinked between guard and eval, and the run died
+    #     on ImportError with no way to see why.
+    #   * The shadow-import risk it was meant to cover is not a capability the
+    #     agent gains this way. The eval scripts import the agent's editable
+    #     file in the very process that prints the metrics the parser reads
+    #     (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so
+    #     arbitrary in-process code is already granted by design. Created files
+    #     cannot reach the verifier either: /tests mounts only at verify time,
+    #     and test.sh resets PATH and unsets every PYTHON* variable first.
+    #   * The sweep needed a hand-maintained allowlist to stay correct. Every
+    #     image-baked path inside a package dir had to be added to
+    #     guard_exclude by hand (dbim-codebase/assets, badge/oml) because the
+    #     render-time manifest never covered them; a missing entry deleted real
+    #     data. Absence from the manifest never meant "the agent made this".
+    #
+    # `allow_create` therefore no longer changes guard behaviour; it is kept in
+    # the task configs as documentation of intent.
 
     # Disallowed deletion: anything in manifest under a guarded prefix that
     # is gone from workspace.
@@ -425,7 +407,7 @@ def cmd_guard(args: argparse.Namespace) -> int:
             continue
         expected_sha = manifest.get(rel_str)
         if expected_sha is None:
-            # Newly created file — handled by allow_create branch above.
+            # Newly created file — not tracked, not a violation.
             continue
         try:
             actual = hashlib.sha256(

--- a/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
+++ b/harbor_adapter/src/mls_bench/task-template/tests/score_task.py
@@ -190,6 +190,16 @@ def _check_editable_only(
         chosen[i] = (start, end)
         prev_end = end
 
+    # With one editable interval, the anchored pristine prefix and suffix are
+    # a complete proof that every fixed byte is unchanged.  SequenceMatcher
+    # can misalign a repeated boundary line (commonly a blank line) with an
+    # identical line inside a replacement, then falsely report the real fixed
+    # boundary as deleted.  Multiple disjoint intervals still need the
+    # line-level backstop below to reject deletion of an intermediate fixed
+    # segment when the editable text contains a duplicate.
+    if len(ranges) == 1:
+        return True, None
+
     editable_line_nos = {
         line_no
         for r in ranges

--- a/harbor_adapter/tests/test_score_task.py
+++ b/harbor_adapter/tests/test_score_task.py
@@ -50,13 +50,21 @@ def _write_guard_fixture(tmp_path: Path, *, allow_create: bool) -> tuple[Path, P
     return task_meta, pristine, workspace, tmp_path / "violation.txt"
 
 
-def test_allow_create_false_outside_prefix(tmp_path: Path):
+def test_created_files_are_neither_flagged_nor_removed(tmp_path: Path):
+    """Creating files is not a violation, and the guard must not delete them.
+
+    Deleting them between guard and eval silently broke agents that split an
+    implementation into a helper module: the import died with no visible cause.
+    Both a workspace-root file and one inside the guarded package prefix must
+    survive.
+    """
     score_task = _load_score_task()
     task_meta, pristine, workspace, violation = _write_guard_fixture(
         tmp_path,
         allow_create=False,
     )
-    (workspace / "sitecustomize.py").write_text("print('bypass')\n")
+    (workspace / "sitecustomize.py").write_text("print('scratch')\n")
+    (workspace / "pkg" / "helper.py").write_text("VALUE = 1\n")
 
     rc = score_task.cmd_guard(argparse.Namespace(
         task_meta=str(task_meta),
@@ -65,8 +73,10 @@ def test_allow_create_false_outside_prefix(tmp_path: Path):
         violation_out=str(violation),
     ))
 
-    assert rc == 10
-    assert "created new file (allow_create=false): sitecustomize.py" in violation.read_text()
+    assert rc == 0, violation.read_text() if violation.exists() else ""
+    assert not violation.exists()
+    assert (workspace / "sitecustomize.py").exists()
+    assert (workspace / "pkg" / "helper.py").exists()
 
 
 def test_verifier_task_dir_exempt(tmp_path: Path):

--- a/harbor_adapter/tests/test_score_task.py
+++ b/harbor_adapter/tests/test_score_task.py
@@ -140,6 +140,27 @@ def test_edit_guard_rejects_deleted_fixed_separator_with_duplicate_in_editable(t
     assert "only the declared editable range" in reason
 
 
+def test_edit_guard_allows_single_range_replacement_with_repeated_suffix_line(tmp_path: Path):
+    """SequenceMatcher must not steal a repeated fixed suffix line.
+
+    The pristine editable line and fixed suffix are intentionally identical.
+    Replacing the editable line leaves the suffix byte-for-byte intact, but a
+    global diff aligns the suffix with the editable occurrence and reports the
+    actual suffix as deleted.
+    """
+    score_task = _load_score_task()
+    pristine = tmp_path / "pristine.py"
+    current = tmp_path / "current.py"
+
+    pristine.write_text("header\nrepeated\nrepeated\n")
+    current.write_text("header\nreplacement\nrepeated\n")
+
+    ranges = [score_task.EditRange(2, 2)]
+    ok, reason = score_task._check_editable_only(pristine, current, ranges)
+
+    assert ok, reason
+
+
 def test_edit_guard_rejects_protected_line_with_open_ended_tail_range(tmp_path: Path):
     """Regression: a disjoint range list whose last range uses end=-1 (to-EOF)
     must NOT mark the whole file editable for the line-level backstop. Here the

--- a/harbor_adapter/tests/test_score_task.py
+++ b/harbor_adapter/tests/test_score_task.py
@@ -456,3 +456,31 @@ def test_partition_group_gpu_batches_serializes_group_overflow():
         [task(f"j{i}", 1.0) for i in range(9)], devices
     )
     assert [len(tasks) for tasks, _ in batches] == [8, 1]
+def test_rendered_bundles_match_the_verifier_template():
+    """Every rendered task ships its own copy of the verifier.
+
+    `harbor/tasks/*/tests/{score_task.py,test.sh}` are plain copies of the
+    task-template files — no Jinja substitution happens on them. A fix landed
+    in the template therefore reaches exactly zero agents until the copies are
+    re-synced, which is silent and easy to miss (it is how the single-range
+    guard fix initially shipped as a no-op). Fail loudly on drift.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    tasks_root = repo_root / "harbor" / "tasks"
+    if not tasks_root.is_dir():
+        return  # adapter-only checkout: nothing rendered to compare against
+
+    template_dir = Path(__file__).resolve().parents[1] / "src" / "mls_bench" / "task-template" / "tests"
+    for name in ("score_task.py", "test.sh"):
+        expected = (template_dir / name).read_bytes()
+        drifted = [
+            p.parents[1].name
+            for p in sorted(tasks_root.glob(f"*/tests/{name}"))
+            if p.read_bytes() != expected
+        ]
+        assert not drifted, (
+            f"{len(drifted)} rendered bundle(s) have a {name} that differs from "
+            f"task-template/tests/{name}: {', '.join(drifted[:5])}"
+            f"{' …' if len(drifted) > 5 else ''}. Re-sync the copies — a template-only "
+            "change does not reach any shipped task."
+        )


### PR DESCRIPTION
Builds on **#69** by @CodingWithTim, whose commit is included unchanged and with authorship preserved. Opened as a separate PR only because the fork does not allow maintainer pushes.

Three commits, no reverts:

```
bb5038e8  Fix single-range verifier guard alignment          (@CodingWithTim)
427ccb92  sync the guard fix into the 140 rendered bundles
027341cf  stop deleting agent-created files
```

## 1. #69's fix is correct — verified adversarially

With a single editable interval, `startswith(prefix)` (`score_task.py:138`), `endswith(suffix)` (`:147`) and the non-overlap check (`:185`) together already prove byte-for-byte that `current == prefix + anything + suffix`. The `SequenceMatcher` backstop can then only produce false positives, so returning early is sound.

Ran the shipped guard and the patched guard side by side over 17 cases. Every attack still denied — delete/modify a fixed head or tail line, append past the tail, prepend before the head, reorder fixed lines, re-create the tail inside the edit and drop the real one, whitespace-only change to a fixed line, move a fixed line into the body, and the `end=-1` variants. Exactly one behaviour changes: the false reject the PR set out to fix. Keeping the backstop for multiple ranges is also the right call — `test_edit_guard_rejects_deleted_fixed_separator_with_duplicate_in_editable` is a case the anchors alone cannot catch.

## 2. But it does not ship — that is what this PR adds

#69 patches `harbor_adapter/src/mls_bench/task-template/tests/score_task.py`. That file is not what runs. Every rendered task carries its own `harbor/tasks/<task>/tests/score_task.py`, a plain copy with no Jinja substitution — byte-identical to the template across all 140. A template-only fix reaches **zero** agents.

This PR copies the fixed verifier into all 140 bundles and adds a test that fails on template/rendered drift for both `score_task.py` and `test.sh`, because that drift is silent: the fix looks merged and the bug keeps firing.

**Measured impact**, using each task's real `tests/meta/pristine` file and its real range from `tests/meta/config.json`, over four edit shapes that touch only the editable region (all legal by construction):

| | |
|---|---|
| tasks declaring exactly one editable range | 110 / 140 |
| tasks rejecting a legal *"replace the stub with a shorter implementation"* | **4** |
| still rejected after the fix | 0 |

The four: `causal-discovery-discrete`, `causal-observational-linear-gaussian`, `mlsys-sparse-attention-inference`, `security-adversarial-attack-sparse-l0`. They share a shape — the fixed suffix is a banner line (`# =====`) that also appears *inside* the editable region, so an agent rewriting the stub and dropping the duplicate banner lets `SequenceMatcher` align the surviving copy with the editable occurrence and report the real fixed line as deleted. This is not a warning: `test.sh` turns guard `rc=10` into `reward.txt = 0` and never runs the eval.

## 3. Stop deleting agent-created files

The guard never failed a run for a created file, but it did `unlink()` every created file under a guarded package prefix, between the guard step and the eval. Three reasons that is the wrong trade:

- **It silently broke legitimate work.** An agent that split its implementation into a helper module and imported it from the editable file had the helper removed before the eval ran. The run died on `ImportError` with nothing in the violation report to explain it.
- **The risk it covered is not a capability the agent gains this way.** Eval scripts import the agent's editable file in the very process that prints the metrics the parser reads (`python -u run.py` → `models/Custom.py` → `TEST_METRICS`), so arbitrary in-process code is already granted by design; a shadow-import adds nothing. Created files cannot reach the verifier either — `/tests` mounts only at verify time, and `test.sh` resets `PATH` and unsets every `PYTHON*` variable before running `score_task.py` with `-I`.
- **It needed a hand-maintained allowlist to stay correct.** Absence from `pristine_manifest.json` never meant "the agent made this" — the manifest is built from the render-time synthetic workspace, so every image-baked path inside a package dir had to be added to `guard_exclude` by hand (`dbim-codebase/assets`, `badge/oml`), and a missing entry deleted real data. An earlier attempt in this PR to widen the sweep hit exactly that: it would have deleted ProteinInvBench's `/workspace/data` and failed every run of `ai4bio-protein-inverse-folding`. That attempt is not in this branch.

What the guard protects is unchanged and re-verified: modifying a fixed file, deleting a fixed file, and deleting a declared editable file all still return `rc=10`. `allow_create` no longer changes guard behaviour and is kept in task configs as documentation of intent.

`test_allow_create_false_outside_prefix` asserted the pre-cleanup hard-fail and **has been red on `main`** since the cleanup replaced it. It is now `test_created_files_are_neither_flagged_nor_removed`, covering a workspace-root file and one inside the guarded prefix. Suite goes 12 passed / 1 failed → **15 passed**.

This closes #73 rather than implementing it: the sweep is removed instead of hardened.

## Known remaining gap in the guard itself (not fixed here)

Multi-range tasks keep the backstop and keep the false reject. Measured: 3 of 72 legal edits across 18 two-range tasks, still rejected after #69 — `ml-continual-regularization` and `marl-centralized-critic`. Both have the same cause: the fixed segment wedged between two editable ranges is a **single blank line**, which occurs 20+ times in the file, so any change to blank-line counts lets the matcher steal it. Fixing that safely needs either a guard redesign or absorbing the lone blank line into an adjacent editable range in the task config — a task-semantics change, so it is left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)