### PR TITLE
robo-diffusion-sampling-method: make the sampler itself the editable surface

### DIFF
--- a/harbor/tasks/dataset.toml
+++ b/harbor/tasks/dataset.toml
@@ -483,7 +483,7 @@ digest = "sha256:59e886ae0eddaae36b88f0d9fe3662e492d8be1b65015ce12e091fd27350b23
 
 [[tasks]]
 name = "mls-bench/robo-diffusion-sampling-method"
-digest = "sha256:cd5406a131d35b190acc7f89d2abd856a299bdecc3b851ffc8f7988b0290955e"
+digest = "sha256:1134c5b087d55d1376210b2d1c1cae491b2e7743c449a33baadd185bc50ba8ee"
 
 [[tasks]]
 name = "mls-bench/robo-humanoid-sim2real-algo"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/environment/_scaffold/CleanDiffuser/pipelines/custom_sampling_method.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/environment/_scaffold/CleanDiffuser/pipelines/custom_sampling_method.py
@@ -36,13 +36,12 @@ def pipeline(args):
     obs_dim, act_dim = dataset.o_dim, dataset.a_dim
 
     # ============================================================================
-    # EDITABLE REGION: Policy Algorithm (lines 40-205)
+    # FIXED: Policy, Critic and Training
     # ============================================================================
-    # Defines the actor (diffusion policy), optional critic(s), training loop,
-    # and inference action-selection. The template defaults to Diffusion
-    # Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q loss.
-    # Baselines may swap in IQL Q+V (idql) or strip the critic entirely
-    # (diffusion_policy = pure BC).
+    # Diffusion Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q
+    # loss. The trained actor/critic, dataset, environment list, seeds and
+    # evaluation loop are fixed — this task is about the sampler, so the thing
+    # you edit is the reverse process at inference time, further below.
 
     # --------------- Network Architecture -----------------
     nn_diffusion = DQLMlp(obs_dim, act_dim, emb_dim=64, timestep_emb_type="positional").to(args.device)
@@ -179,6 +178,24 @@ def pipeline(args):
         normalizer = dataset.get_normalizer()
         episode_rewards = []
 
+        # ============================================================================
+        # FIXED: NFE accounting — do not modify
+        # ============================================================================
+        # Counts real denoiser evaluations with a forward hook, so the reported
+        # NFE is what your sampler actually spends rather than a number declared
+        # in a config file. One hook call == one network evaluation, whatever
+        # batch it carries.
+        _nfe = {"calls": 0, "samples": 0}
+
+        def _count_nfe(_module, _inputs, _output):
+            _nfe["calls"] += 1
+
+        for _m in (actor.model, actor.model_ema):
+            try:
+                _m["diffusion"].register_forward_hook(_count_nfe)
+            except (KeyError, TypeError, AttributeError):
+                pass
+
         prior = torch.zeros((args.num_envs * args.num_candidates, act_dim), device=args.device)
         for i in range(args.num_episodes):
 
@@ -188,6 +205,27 @@ def pipeline(args):
                 obs = torch.tensor(normalizer.normalize(obs), device=args.device, dtype=torch.float32)
                 obs = obs.unsqueeze(1).repeat(1, args.num_candidates, 1).view(-1, obs_dim)
 
+                _nfe["samples"] += 1
+
+                # ====================================================================
+                # EDITABLE REGION: Sampling Algorithm
+                # ====================================================================
+                # Produce `act` of shape [num_envs * num_candidates, act_dim] by
+                # running a reverse diffusion process conditioned on `obs`.
+                #
+                # The default below delegates to CleanDiffuser's built-in solvers,
+                # driven by `solver` / `sampling_steps` in the YAML. You are not
+                # limited to that: implement the reverse process yourself and call
+                # the denoiser directly —
+                #
+                #   net = actor.model_ema["diffusion"] if args.use_ema else actor.model["diffusion"]
+                #   pred = net(x_t, t, cond)        # eps or x0, per actor.predict_noise
+                #
+                # with the schedule available from actor.alphas / actor.sigmas (see
+                # cleandiffuser/diffusion/diffusionsde.py). Fewer evaluations at the
+                # same return is the point: every call to the denoiser is counted and
+                # reported as the NFE the score penalizes, so the cost you pay is the
+                # cost you are scored on.
                 act, log = actor.sample(
                     prior,
                     solver=args.solver,
@@ -195,6 +233,9 @@ def pipeline(args):
                     sample_steps=args.sampling_steps,
                     condition_cfg=obs, w_cfg=1.0,
                     use_ema=args.use_ema, temperature=args.temperature)
+                # ====================================================================
+                # FIXED: Candidate Selection and Environment Step
+                # ====================================================================
 
                 with torch.no_grad():
                     q = critic_target.q_min(obs, act)
@@ -223,6 +264,13 @@ def pipeline(args):
         std_score = float(np.std(episode_rewards))
         mean_ep_reward = float(np.mean(raw_episode_rewards))
         print(f"EVAL_METRICS normalized_score={mean_score:.4f} normalized_score_std={std_score:.4f} episode_reward={mean_ep_reward:.2f}")
+
+        # Ceil, not round: an adaptive sampler averaging 10.5 evaluations must
+        # not report 10 and collect the full no-penalty credit reserved for a
+        # 10-step budget. Round-half-to-even would also floor an average of 0.5
+        # to zero. Constant-call samplers are unaffected.
+        measured_nfe = -(-_nfe["calls"] // max(_nfe["samples"], 1))
+        print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
 
     else:
         raise ValueError(f"Invalid mode: {args.mode}")

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/instruction.md
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/instruction.md
@@ -5,7 +5,7 @@
 ## Objective
 Design a single efficient diffusion sampler for a fixed DQL-style diffusion policy that achieves high quality at low inference NFE (number of function evaluations).
 
-This task is deliberately about inference-time sampler choice, not policy learning, guidance, or trajectory planning. The trained actor / critic, dataset, environment list, seeds, and evaluation loop are fixed.
+This task is deliberately about the inference-time reverse process, not policy learning, guidance, or trajectory planning. The trained actor / critic, dataset, environment list, seeds, and evaluation loop are fixed.
 
 ## Background
 A diffusion policy's wall-clock inference cost is dominated by the number of reverse-process steps. Different ODE / SDE solvers reach a given sample quality at different NFE budgets:
@@ -16,15 +16,15 @@ A diffusion policy's wall-clock inference cost is dominated by the number of rev
 The setup builds on **CleanDiffuser** (Dong et al., NeurIPS 2024, arXiv:2406.09509) and the underlying actor is a DQL-style diffusion policy (Wang et al., ICLR 2023, arXiv:2208.06193) trained on **D4RL** (Fu et al., 2020, arXiv:2004.07219).
 
 ## What You Can Modify
-- `solver` in `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`
-- `sampling_steps` in the same YAML file
+- The **sampling algorithm itself** — the `EDITABLE REGION: Sampling Algorithm` block in `CleanDiffuser/pipelines/custom_sampling_method.py`, which turns a prior and an observation into actions. The default delegates to CleanDiffuser's built-in solvers; you may instead write the reverse process yourself, calling the denoiser (`actor.model_ema["diffusion"]`) directly with whatever discretization, step schedule, order or correction you want.
+- `solver` and `sampling_steps` in `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`, which drive the default implementation.
 
 ## What Is Fixed
-- The pipeline code, model architecture, critic, and training objective
+- The actor and critic architectures, the training objective and the training loop
 - `diffusion_steps`, training budgets, checkpoint selection, and EMA use
-- The environments, seeds, and vectorized evaluation loop
+- Candidate selection, the environments, seeds, and vectorized evaluation loop
 
-The `sampling_steps` field you set controls how many reverse-process steps the sampler takes at inference. Custom pipeline-code samplers are intentionally out of scope here.
+NFE is **measured, not declared**: a forward hook on the denoiser counts real network evaluations during evaluation and reports the average per action sample. Writing your own reverse process is therefore in scope — a sampler that spends 40 evaluations is scored as 40 no matter what any config field says, and one that reaches the same return in 10 is scored as 10.
 
 ## Baselines
 
@@ -54,6 +54,8 @@ The line numbers mark an editable **region**, not a fixed line-count budget: you
 may add or remove lines inside it. Only code outside the editable ranges must
 stay unchanged.
 
+- `CleanDiffuser/pipelines/custom_sampling_method.py`
+- editable lines **213–235**
 - `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`
 - editable lines **15–15**
 - editable lines **17–17**
@@ -65,6 +67,291 @@ Other files you may **read** for context (do not modify):
 
 ## Readable Context
 
+
+### `CleanDiffuser/pipelines/custom_sampling_method.py`  [EDITABLE — lines 213–235 only]
+
+```python
+     1: import os
+     2: from copy import deepcopy
+     3: 
+     4: import d4rl
+     5: import gym
+     6: import hydra
+     7: import numpy as np
+     8: import torch
+     9: import torch.nn.functional as F
+    10: from torch.optim.lr_scheduler import CosineAnnealingLR
+    11: from torch.utils.data import DataLoader
+    12: 
+    13: from cleandiffuser.dataset.d4rl_mujoco_dataset import D4RLMuJoCoTDDataset
+    14: from cleandiffuser.dataset.dataset_utils import loop_dataloader
+    15: from cleandiffuser.diffusion import DiscreteDiffusionSDE
+    16: from cleandiffuser.nn_condition import IdentityCondition
+    17: from cleandiffuser.nn_diffusion import DQLMlp
+    18: from cleandiffuser.utils import report_parameters, DQLCritic, FreezeModules
+    19: from utils import set_seed
+    20: 
+    21: 
+    22: @hydra.main(config_path="../configs/custom/mujoco", config_name="mujoco", version_base=None)
+    23: def pipeline(args):
+    24: 
+    25:     set_seed(args.seed)
+    26: 
+    27:     save_path = f'results/{args.pipeline_name}/{args.task.env_name}/'
+    28:     if os.path.exists(save_path) is False:
+    29:         os.makedirs(save_path)
+    30: 
+    31:     # ---------------------- Create Dataset ----------------------
+    32:     env = gym.make(args.task.env_name)
+    33:     dataset = D4RLMuJoCoTDDataset(d4rl.qlearning_dataset(env), args.normalize_reward)
+    34:     dataloader = DataLoader(
+    35:         dataset, batch_size=args.batch_size, shuffle=True, num_workers=4, pin_memory=True, drop_last=True)
+    36:     obs_dim, act_dim = dataset.o_dim, dataset.a_dim
+    37: 
+    38:     # ============================================================================
+    39:     # FIXED: Policy, Critic and Training
+    40:     # ============================================================================
+    41:     # Diffusion Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q
+    42:     # loss. The trained actor/critic, dataset, environment list, seeds and
+    43:     # evaluation loop are fixed — this task is about the sampler, so the thing
+    44:     # you edit is the reverse process at inference time, further below.
+    45: 
+    46:     # --------------- Network Architecture -----------------
+    47:     nn_diffusion = DQLMlp(obs_dim, act_dim, emb_dim=64, timestep_emb_type="positional").to(args.device)
+    48:     nn_condition = IdentityCondition(dropout=0.0).to(args.device)
+    49: 
+    50:     print(f"======================= Parameter Report of Diffusion Model =======================")
+    51:     report_parameters(nn_diffusion)
+    52:     print(f"==============================================================================")
+    53: 
+    54:     # --------------- Diffusion Model Actor --------------------
+    55:     actor = DiscreteDiffusionSDE(
+    56:         nn_diffusion, nn_condition, predict_noise=args.predict_noise, optim_params={"lr": args.actor_learning_rate},
+    57:         x_max=+1. * torch.ones((1, act_dim), device=args.device),
+    58:         x_min=-1. * torch.ones((1, act_dim), device=args.device),
+    59:         diffusion_steps=args.diffusion_steps, ema_rate=args.ema_rate, device=args.device)
+    60: 
+    61:     # ------------------ Critic ---------------------
+    62:     critic = DQLCritic(obs_dim, act_dim, hidden_dim=args.hidden_dim).to(args.device)
+    63:     critic_target = deepcopy(critic).requires_grad_(False).eval()
+    64:     critic_optim = torch.optim.Adam(critic.parameters(), lr=args.critic_learning_rate)
+    65: 
+    66:     # ---------------------- Training ----------------------
+    67:     if args.mode == "train":
+    68: 
+    69:         actor_lr_scheduler = CosineAnnealingLR(actor.optimizer, T_max=args.gradient_steps)
+    70:         critic_lr_scheduler = CosineAnnealingLR(critic_optim, T_max=args.gradient_steps)
+    71: 
+    72:         actor.train()
+    73:         critic.train()
+    74: 
+    75:         n_gradient_step = 0
+    76:         log = {"bc_loss": 0., "q_loss": 0., "critic_loss": 0., "target_q_mean": 0.}
+    77: 
+    78:         prior = torch.zeros((args.batch_size, act_dim), device=args.device)
+    79: 
+    80:         for batch in loop_dataloader(dataloader):
+    81: 
+    82:             obs, next_obs = batch["obs"]["state"].to(args.device), batch["next_obs"]["state"].to(args.device)
+    83:             act = batch["act"].to(args.device)
+    84:             rew = batch["rew"].to(args.device)
+    85:             tml = batch["tml"].to(args.device)
+    86: 
+    87:             # Critic Training
+    88:             current_q1, current_q2 = critic(obs, act)
+    89: 
+    90:             next_act, _ = actor.sample(
+    91:                 prior, solver=args.solver,
+    92:                 n_samples=args.batch_size, sample_steps=args.sampling_steps, use_ema=True,
+    93:                 temperature=1.0, condition_cfg=next_obs, w_cfg=1.0, requires_grad=False)
+    94: 
+    95:             target_q = torch.min(*critic_target(next_obs, next_act))
+    96:             target_q = (rew + (1 - tml) * args.discount * target_q).detach()
+    97: 
+    98:             critic_loss = F.mse_loss(current_q1, target_q) + F.mse_loss(current_q2, target_q)
+    99: 
+   100:             critic_optim.zero_grad()
+   101:             critic_loss.backward()
+   102:             critic_optim.step()
+   103: 
+   104:             # Policy Training
+   105:             bc_loss = actor.loss(act, obs)
+   106:             new_act, _ = actor.sample(
+   107:                 prior, solver=args.solver,
+   108:                 n_samples=args.batch_size, sample_steps=args.sampling_steps, use_ema=False,
+   109:                 temperature=1.0, condition_cfg=obs, w_cfg=1.0, requires_grad=True)
+   110: 
+   111:             with FreezeModules([critic, ]):
+   112:                 q1_new_action, q2_new_action = critic(obs, new_act)
+   113:             if np.random.uniform() > 0.5:
+   114:                 q_loss = - q1_new_action.mean() / q2_new_action.abs().mean().detach()
+   115:             else:
+   116:                 q_loss = - q2_new_action.mean() / q1_new_action.abs().mean().detach()
+   117:             actor_loss = bc_loss + args.task.eta * q_loss
+   118: 
+   119:             actor.optimizer.zero_grad()
+   120:             actor_loss.backward()
+   121:             actor.optimizer.step()
+   122: 
+   123:             actor_lr_scheduler.step()
+   124:             critic_lr_scheduler.step()
+   125: 
+   126:             # ema
+   127:             if n_gradient_step % args.ema_update_interval == 0:
+   128:                 if n_gradient_step >= 1000:
+   129:                     actor.ema_update()
+   130:                 for param, target_param in zip(critic.parameters(), critic_target.parameters()):
+   131:                     target_param.data.copy_(0.995 * param.data + (1 - 0.995) * target_param.data)
+   132: 
+   133:             log["bc_loss"] += bc_loss.item()
+   134:             log["q_loss"] += q_loss.item()
+   135:             log["critic_loss"] += critic_loss.item()
+   136:             log["target_q_mean"] += target_q.mean().item()
+   137: 
+   138:             if (n_gradient_step + 1) % args.log_interval == 0:
+   139:                 log["gradient_steps"] = n_gradient_step + 1
+   140:                 log["bc_loss"] /= args.log_interval
+   141:                 log["q_loss"] /= args.log_interval
+   142:                 log["critic_loss"] /= args.log_interval
+   143:                 log["target_q_mean"] /= args.log_interval
+   144:                 print(f"TRAIN_METRICS gradient_steps={log['gradient_steps']} "
+   145:                       f"bc_loss={log['bc_loss']:.4f} q_loss={log['q_loss']:.4f} "
+   146:                       f"critic_loss={log['critic_loss']:.4f} target_q_mean={log['target_q_mean']:.4f}")
+   147:                 log = {"bc_loss": 0., "q_loss": 0., "critic_loss": 0., "target_q_mean": 0.}
+   148: 
+   149:             if (n_gradient_step + 1) % args.save_interval == 0:
+   150:                 actor.save(save_path + f"diffusion_ckpt_{n_gradient_step + 1}.pt")
+   151:                 actor.save(save_path + f"diffusion_ckpt_latest.pt")
+   152:                 torch.save({
+   153:                     "critic": critic.state_dict(),
+   154:                     "critic_target": critic_target.state_dict(),
+   155:                 }, save_path + f"critic_ckpt_{n_gradient_step + 1}.pt")
+   156:                 torch.save({
+   157:                     "critic": critic.state_dict(),
+   158:                     "critic_target": critic_target.state_dict(),
+   159:                 }, save_path + f"critic_ckpt_latest.pt")
+   160: 
+   161:             n_gradient_step += 1
+   162:             if n_gradient_step >= args.gradient_steps:
+   163:                 break
+   164: 
+   165:     # ---------------------- Inference ----------------------
+   166:     elif args.mode == "inference":
+   167: 
+   168:         actor.load(save_path + f"diffusion_ckpt_{args.ckpt}.pt")
+   169:         critic_ckpt = torch.load(save_path + f"critic_ckpt_{args.ckpt}.pt")
+   170:         critic.load_state_dict(critic_ckpt["critic"])
+   171:         critic_target.load_state_dict(critic_ckpt["critic_target"])
+   172: 
+   173:         actor.eval()
+   174:         critic.eval()
+   175:         critic_target.eval()
+   176: 
+   177:         env_eval = gym.vector.make(args.task.env_name, args.num_envs)
+   178:         normalizer = dataset.get_normalizer()
+   179:         episode_rewards = []
+   180: 
+   181:         # ============================================================================
+   182:         # FIXED: NFE accounting — do not modify
+   183:         # ============================================================================
+   184:         # Counts real denoiser evaluations with a forward hook, so the reported
+   185:         # NFE is what your sampler actually spends rather than a number declared
+   186:         # in a config file. One hook call == one network evaluation, whatever
+   187:         # batch it carries.
+   188:         _nfe = {"calls": 0, "samples": 0}
+   189: 
+   190:         def _count_nfe(_module, _inputs, _output):
+   191:             _nfe["calls"] += 1
+   192: 
+   193:         for _m in (actor.model, actor.model_ema):
+   194:             try:
+   195:                 _m["diffusion"].register_forward_hook(_count_nfe)
+   196:             except (KeyError, TypeError, AttributeError):
+   197:                 pass
+   198: 
+   199:         prior = torch.zeros((args.num_envs * args.num_candidates, act_dim), device=args.device)
+   200:         for i in range(args.num_episodes):
+   201: 
+   202:             env_eval.seed(args.seed + i * args.num_envs) if hasattr(env_eval, "seed") else None; obs, ep_reward, cum_done, t = env_eval.reset(), 0., 0., 0
+   203: 
+   204:             while not np.all(cum_done) and t < 1000 + 1:
+   205:                 obs = torch.tensor(normalizer.normalize(obs), device=args.device, dtype=torch.float32)
+   206:                 obs = obs.unsqueeze(1).repeat(1, args.num_candidates, 1).view(-1, obs_dim)
+   207: 
+   208:                 _nfe["samples"] += 1
+   209: 
+   210:                 # ====================================================================
+   211:                 # EDITABLE REGION: Sampling Algorithm
+   212:                 # ====================================================================
+   213:                 # Produce `act` of shape [num_envs * num_candidates, act_dim] by
+   214:                 # running a reverse diffusion process conditioned on `obs`.
+   215:                 #
+   216:                 # The default below delegates to CleanDiffuser's built-in solvers,
+   217:                 # driven by `solver` / `sampling_steps` in the YAML. You are not
+   218:                 # limited to that: implement the reverse process yourself and call
+   219:                 # the denoiser directly —
+   220:                 #
+   221:                 #   net = actor.model_ema["diffusion"] if args.use_ema else actor.model["diffusion"]
+   222:                 #   pred = net(x_t, t, cond)        # eps or x0, per actor.predict_noise
+   223:                 #
+   224:                 # with the schedule available from actor.alphas / actor.sigmas (see
+   225:                 # cleandiffuser/diffusion/diffusionsde.py). Fewer evaluations at the
+   226:                 # same return is the point: every call to the denoiser is counted and
+   227:                 # reported as the NFE the score penalizes, so the cost you pay is the
+   228:                 # cost you are scored on.
+   229:                 act, log = actor.sample(
+   230:                     prior,
+   231:                     solver=args.solver,
+   232:                     n_samples=args.num_envs * args.num_candidates,
+   233:                     sample_steps=args.sampling_steps,
+   234:                     condition_cfg=obs, w_cfg=1.0,
+   235:                     use_ema=args.use_ema, temperature=args.temperature)
+   236:                 # ====================================================================
+   237:                 # FIXED: Candidate Selection and Environment Step
+   238:                 # ====================================================================
+   239: 
+   240:                 with torch.no_grad():
+   241:                     q = critic_target.q_min(obs, act)
+   242:                     q = q.view(-1, args.num_candidates, 1)
+   243:                     w = torch.softmax(q * args.task.weight_temperature, 1)
+   244:                     act = act.view(-1, args.num_candidates, act_dim)
+   245: 
+   246:                     indices = torch.multinomial(w.squeeze(-1), 1).squeeze(-1)
+   247:                     sampled_act = act[torch.arange(act.shape[0]), indices].cpu().numpy()
+   248: 
+   249:                 obs, rew, done, info = env_eval.step(sampled_act)
+   250: 
+   251:                 t += 1
+   252:                 cum_done = done if cum_done is None else np.logical_or(cum_done, done)
+   253:                 ep_reward += (rew * (1 - cum_done)) if t < 1000 else rew
+   254: 
+   255:                 if np.all(cum_done):
+   256:                     break
+   257: 
+   258:             episode_rewards.append(ep_reward)
+   259: 
+   260:         raw_episode_rewards = episode_rewards
+   261:         episode_rewards = [list(map(lambda x: env.get_normalized_score(x), r)) for r in episode_rewards]
+   262:         episode_rewards = np.array(episode_rewards)
+   263:         mean_score = float(np.mean(episode_rewards))
+   264:         std_score = float(np.std(episode_rewards))
+   265:         mean_ep_reward = float(np.mean(raw_episode_rewards))
+   266:         print(f"EVAL_METRICS normalized_score={mean_score:.4f} normalized_score_std={std_score:.4f} episode_reward={mean_ep_reward:.2f}")
+   267: 
+   268:         # Ceil, not round: an adaptive sampler averaging 10.5 evaluations must
+   269:         # not report 10 and collect the full no-penalty credit reserved for a
+   270:         # 10-step budget. Round-half-to-even would also floor an average of 0.5
+   271:         # to zero. Constant-call samplers are unaffected.
+   272:         measured_nfe = -(-_nfe["calls"] // max(_nfe["samples"], 1))
+   273:         print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
+   274: 
+   275:     else:
+   276:         raise ValueError(f"Invalid mode: {args.mode}")
+   277: 
+   278: 
+   279: if __name__ == "__main__":
+   280:     pipeline()
+```
 
 ### `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`  [EDITABLE — lines 15–15, lines 17–17 only]
 

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_halfcheetah.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_halfcheetah.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_hopper.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_hopper.sh
@@ -4,6 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=train seed=$SEED gradient_steps=300000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=inference seed=$SEED ckpt=300000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-# Emit NFE so the score can penalize methods that need many sampling steps.
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_walker2d.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/eval/scripts/train_walker2d.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/config.json
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/config.json
@@ -46,7 +46,12 @@
           "end": -1
         }
       ],
-      "edit": []
+      "edit": [
+        {
+          "start": 213,
+          "end": 235
+        }
+      ]
     },
     {
       "filename": "CleanDiffuser/configs/custom/mujoco/mujoco.yaml",

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/edits/custom_template.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/edits/custom_template.py
@@ -36,13 +36,12 @@ def pipeline(args):
     obs_dim, act_dim = dataset.o_dim, dataset.a_dim
 
     # ============================================================================
-    # EDITABLE REGION: Policy Algorithm (lines 40-205)
+    # FIXED: Policy, Critic and Training
     # ============================================================================
-    # Defines the actor (diffusion policy), optional critic(s), training loop,
-    # and inference action-selection. The template defaults to Diffusion
-    # Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q loss.
-    # Baselines may swap in IQL Q+V (idql) or strip the critic entirely
-    # (diffusion_policy = pure BC).
+    # Diffusion Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q
+    # loss. The trained actor/critic, dataset, environment list, seeds and
+    # evaluation loop are fixed — this task is about the sampler, so the thing
+    # you edit is the reverse process at inference time, further below.
 
     # --------------- Network Architecture -----------------
     nn_diffusion = DQLMlp(obs_dim, act_dim, emb_dim=64, timestep_emb_type="positional").to(args.device)
@@ -179,6 +178,24 @@ def pipeline(args):
         normalizer = dataset.get_normalizer()
         episode_rewards = []
 
+        # ============================================================================
+        # FIXED: NFE accounting — do not modify
+        # ============================================================================
+        # Counts real denoiser evaluations with a forward hook, so the reported
+        # NFE is what your sampler actually spends rather than a number declared
+        # in a config file. One hook call == one network evaluation, whatever
+        # batch it carries.
+        _nfe = {"calls": 0, "samples": 0}
+
+        def _count_nfe(_module, _inputs, _output):
+            _nfe["calls"] += 1
+
+        for _m in (actor.model, actor.model_ema):
+            try:
+                _m["diffusion"].register_forward_hook(_count_nfe)
+            except (KeyError, TypeError, AttributeError):
+                pass
+
         prior = torch.zeros((args.num_envs * args.num_candidates, act_dim), device=args.device)
         for i in range(args.num_episodes):
 
@@ -188,6 +205,27 @@ def pipeline(args):
                 obs = torch.tensor(normalizer.normalize(obs), device=args.device, dtype=torch.float32)
                 obs = obs.unsqueeze(1).repeat(1, args.num_candidates, 1).view(-1, obs_dim)
 
+                _nfe["samples"] += 1
+
+                # ====================================================================
+                # EDITABLE REGION: Sampling Algorithm
+                # ====================================================================
+                # Produce `act` of shape [num_envs * num_candidates, act_dim] by
+                # running a reverse diffusion process conditioned on `obs`.
+                #
+                # The default below delegates to CleanDiffuser's built-in solvers,
+                # driven by `solver` / `sampling_steps` in the YAML. You are not
+                # limited to that: implement the reverse process yourself and call
+                # the denoiser directly —
+                #
+                #   net = actor.model_ema["diffusion"] if args.use_ema else actor.model["diffusion"]
+                #   pred = net(x_t, t, cond)        # eps or x0, per actor.predict_noise
+                #
+                # with the schedule available from actor.alphas / actor.sigmas (see
+                # cleandiffuser/diffusion/diffusionsde.py). Fewer evaluations at the
+                # same return is the point: every call to the denoiser is counted and
+                # reported as the NFE the score penalizes, so the cost you pay is the
+                # cost you are scored on.
                 act, log = actor.sample(
                     prior,
                     solver=args.solver,
@@ -195,6 +233,9 @@ def pipeline(args):
                     sample_steps=args.sampling_steps,
                     condition_cfg=obs, w_cfg=1.0,
                     use_ema=args.use_ema, temperature=args.temperature)
+                # ====================================================================
+                # FIXED: Candidate Selection and Environment Step
+                # ====================================================================
 
                 with torch.no_grad():
                     q = critic_target.q_min(obs, act)
@@ -223,6 +264,13 @@ def pipeline(args):
         std_score = float(np.std(episode_rewards))
         mean_ep_reward = float(np.mean(raw_episode_rewards))
         print(f"EVAL_METRICS normalized_score={mean_score:.4f} normalized_score_std={std_score:.4f} episode_reward={mean_ep_reward:.2f}")
+
+        # Ceil, not round: an adaptive sampler averaging 10.5 evaluations must
+        # not report 10 and collect the full no-penalty credit reserved for a
+        # 10-step budget. Round-half-to-even would also floor an average of 0.5
+        # to zero. Constant-call samplers are unaffected.
+        measured_nfe = -(-_nfe["calls"] // max(_nfe["samples"], 1))
+        print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
 
     else:
         raise ValueError(f"Invalid mode: {args.mode}")

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/pristine/CleanDiffuser/pipelines/custom_sampling_method.py
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/pristine/CleanDiffuser/pipelines/custom_sampling_method.py
@@ -36,13 +36,12 @@ def pipeline(args):
     obs_dim, act_dim = dataset.o_dim, dataset.a_dim
 
     # ============================================================================
-    # EDITABLE REGION: Policy Algorithm (lines 40-205)
+    # FIXED: Policy, Critic and Training
     # ============================================================================
-    # Defines the actor (diffusion policy), optional critic(s), training loop,
-    # and inference action-selection. The template defaults to Diffusion
-    # Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q loss.
-    # Baselines may swap in IQL Q+V (idql) or strip the critic entirely
-    # (diffusion_policy = pure BC).
+    # Diffusion Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q
+    # loss. The trained actor/critic, dataset, environment list, seeds and
+    # evaluation loop are fixed — this task is about the sampler, so the thing
+    # you edit is the reverse process at inference time, further below.
 
     # --------------- Network Architecture -----------------
     nn_diffusion = DQLMlp(obs_dim, act_dim, emb_dim=64, timestep_emb_type="positional").to(args.device)
@@ -179,6 +178,24 @@ def pipeline(args):
         normalizer = dataset.get_normalizer()
         episode_rewards = []
 
+        # ============================================================================
+        # FIXED: NFE accounting — do not modify
+        # ============================================================================
+        # Counts real denoiser evaluations with a forward hook, so the reported
+        # NFE is what your sampler actually spends rather than a number declared
+        # in a config file. One hook call == one network evaluation, whatever
+        # batch it carries.
+        _nfe = {"calls": 0, "samples": 0}
+
+        def _count_nfe(_module, _inputs, _output):
+            _nfe["calls"] += 1
+
+        for _m in (actor.model, actor.model_ema):
+            try:
+                _m["diffusion"].register_forward_hook(_count_nfe)
+            except (KeyError, TypeError, AttributeError):
+                pass
+
         prior = torch.zeros((args.num_envs * args.num_candidates, act_dim), device=args.device)
         for i in range(args.num_episodes):
 
@@ -188,6 +205,27 @@ def pipeline(args):
                 obs = torch.tensor(normalizer.normalize(obs), device=args.device, dtype=torch.float32)
                 obs = obs.unsqueeze(1).repeat(1, args.num_candidates, 1).view(-1, obs_dim)
 
+                _nfe["samples"] += 1
+
+                # ====================================================================
+                # EDITABLE REGION: Sampling Algorithm
+                # ====================================================================
+                # Produce `act` of shape [num_envs * num_candidates, act_dim] by
+                # running a reverse diffusion process conditioned on `obs`.
+                #
+                # The default below delegates to CleanDiffuser's built-in solvers,
+                # driven by `solver` / `sampling_steps` in the YAML. You are not
+                # limited to that: implement the reverse process yourself and call
+                # the denoiser directly —
+                #
+                #   net = actor.model_ema["diffusion"] if args.use_ema else actor.model["diffusion"]
+                #   pred = net(x_t, t, cond)        # eps or x0, per actor.predict_noise
+                #
+                # with the schedule available from actor.alphas / actor.sigmas (see
+                # cleandiffuser/diffusion/diffusionsde.py). Fewer evaluations at the
+                # same return is the point: every call to the denoiser is counted and
+                # reported as the NFE the score penalizes, so the cost you pay is the
+                # cost you are scored on.
                 act, log = actor.sample(
                     prior,
                     solver=args.solver,
@@ -195,6 +233,9 @@ def pipeline(args):
                     sample_steps=args.sampling_steps,
                     condition_cfg=obs, w_cfg=1.0,
                     use_ema=args.use_ema, temperature=args.temperature)
+                # ====================================================================
+                # FIXED: Candidate Selection and Environment Step
+                # ====================================================================
 
                 with torch.no_grad():
                     q = critic_target.q_min(obs, act)
@@ -223,6 +264,13 @@ def pipeline(args):
         std_score = float(np.std(episode_rewards))
         mean_ep_reward = float(np.mean(raw_episode_rewards))
         print(f"EVAL_METRICS normalized_score={mean_score:.4f} normalized_score_std={std_score:.4f} episode_reward={mean_ep_reward:.2f}")
+
+        # Ceil, not round: an adaptive sampler averaging 10.5 evaluations must
+        # not report 10 and collect the full no-penalty credit reserved for a
+        # 10-step budget. Round-half-to-even would also floor an average of 0.5
+        # to zero. Constant-call samplers are unaffected.
+        measured_nfe = -(-_nfe["calls"] // max(_nfe["samples"], 1))
+        print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
 
     else:
         raise ValueError(f"Invalid mode: {args.mode}")

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/pristine_manifest.json
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/pristine_manifest.json
@@ -516,7 +516,7 @@
   "CleanDiffuser/pipelines/adaptdiffuser_d4rl_antmaze.py": "07e31b5c606c4d5fbd506acbc72fcd2fec1dba941e3fbc09fac162059e85390c",
   "CleanDiffuser/pipelines/adaptdiffuser_d4rl_kitchen.py": "11d5aa19319b591e7af8a7d44651b38edc8eaed64f35a743cef5895d2edc4206",
   "CleanDiffuser/pipelines/adaptdiffuser_d4rl_mujoco.py": "b7a4a54bf082e41a16a55488ef562282a949dcad2c8ac5b52838d45399a25983",
-  "CleanDiffuser/pipelines/custom_sampling_method.py": "32a0e2d5c6c9bb52fc6d0eecc5585bdec77f29275463ab2f15b7b2017c9e10f9",
+  "CleanDiffuser/pipelines/custom_sampling_method.py": "d42d27e33a58a63e11e5d934fa2de06adb01a6f462f4228f36d45d9374c1efde",
   "CleanDiffuser/pipelines/dbc_kitchen.py": "4e219c4d1aef4757b0a726f0c373653dfe59e355e5d4e4a0f6cc7f9eb0fee0d2",
   "CleanDiffuser/pipelines/dbc_pusht.py": "c742abe1bb67c82421437fe9f4c8474409c628849b27b6b9c196d4a2167aae33",
   "CleanDiffuser/pipelines/dbc_pusht_image.py": "99e80656234fc6c463da92334eed3f3072041dec01035119ba135ecdf3c0b1f8",

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_halfcheetah.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_halfcheetah.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_hopper.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_hopper.sh
@@ -4,6 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=train seed=$SEED gradient_steps=300000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=inference seed=$SEED ckpt=300000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-# Emit NFE so the score can penalize methods that need many sampling steps.
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_walker2d.sh
+++ b/harbor/tasks/mls-bench__robo-diffusion-sampling-method/tests/meta/scripts/train_walker2d.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/tasks/robo-diffusion-sampling-method/config.json
+++ b/tasks/robo-diffusion-sampling-method/config.json
@@ -46,7 +46,12 @@
           "end": -1
         }
       ],
-      "edit": []
+      "edit": [
+        {
+          "start": 213,
+          "end": 235
+        }
+      ]
     },
     {
       "filename": "CleanDiffuser/configs/custom/mujoco/mujoco.yaml",

--- a/tasks/robo-diffusion-sampling-method/edits/custom_template.py
+++ b/tasks/robo-diffusion-sampling-method/edits/custom_template.py
@@ -36,13 +36,12 @@ def pipeline(args):
     obs_dim, act_dim = dataset.o_dim, dataset.a_dim
 
     # ============================================================================
-    # EDITABLE REGION: Policy Algorithm (lines 40-205)
+    # FIXED: Policy, Critic and Training
     # ============================================================================
-    # Defines the actor (diffusion policy), optional critic(s), training loop,
-    # and inference action-selection. The template defaults to Diffusion
-    # Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q loss.
-    # Baselines may swap in IQL Q+V (idql) or strip the critic entirely
-    # (diffusion_policy = pure BC).
+    # Diffusion Q-Learning (DQL): diffusion actor + twin Q critic with BC + Q
+    # loss. The trained actor/critic, dataset, environment list, seeds and
+    # evaluation loop are fixed — this task is about the sampler, so the thing
+    # you edit is the reverse process at inference time, further below.
 
     # --------------- Network Architecture -----------------
     nn_diffusion = DQLMlp(obs_dim, act_dim, emb_dim=64, timestep_emb_type="positional").to(args.device)
@@ -179,6 +178,24 @@ def pipeline(args):
         normalizer = dataset.get_normalizer()
         episode_rewards = []
 
+        # ============================================================================
+        # FIXED: NFE accounting — do not modify
+        # ============================================================================
+        # Counts real denoiser evaluations with a forward hook, so the reported
+        # NFE is what your sampler actually spends rather than a number declared
+        # in a config file. One hook call == one network evaluation, whatever
+        # batch it carries.
+        _nfe = {"calls": 0, "samples": 0}
+
+        def _count_nfe(_module, _inputs, _output):
+            _nfe["calls"] += 1
+
+        for _m in (actor.model, actor.model_ema):
+            try:
+                _m["diffusion"].register_forward_hook(_count_nfe)
+            except (KeyError, TypeError, AttributeError):
+                pass
+
         prior = torch.zeros((args.num_envs * args.num_candidates, act_dim), device=args.device)
         for i in range(args.num_episodes):
 
@@ -188,6 +205,27 @@ def pipeline(args):
                 obs = torch.tensor(normalizer.normalize(obs), device=args.device, dtype=torch.float32)
                 obs = obs.unsqueeze(1).repeat(1, args.num_candidates, 1).view(-1, obs_dim)
 
+                _nfe["samples"] += 1
+
+                # ====================================================================
+                # EDITABLE REGION: Sampling Algorithm
+                # ====================================================================
+                # Produce `act` of shape [num_envs * num_candidates, act_dim] by
+                # running a reverse diffusion process conditioned on `obs`.
+                #
+                # The default below delegates to CleanDiffuser's built-in solvers,
+                # driven by `solver` / `sampling_steps` in the YAML. You are not
+                # limited to that: implement the reverse process yourself and call
+                # the denoiser directly —
+                #
+                #   net = actor.model_ema["diffusion"] if args.use_ema else actor.model["diffusion"]
+                #   pred = net(x_t, t, cond)        # eps or x0, per actor.predict_noise
+                #
+                # with the schedule available from actor.alphas / actor.sigmas (see
+                # cleandiffuser/diffusion/diffusionsde.py). Fewer evaluations at the
+                # same return is the point: every call to the denoiser is counted and
+                # reported as the NFE the score penalizes, so the cost you pay is the
+                # cost you are scored on.
                 act, log = actor.sample(
                     prior,
                     solver=args.solver,
@@ -195,6 +233,9 @@ def pipeline(args):
                     sample_steps=args.sampling_steps,
                     condition_cfg=obs, w_cfg=1.0,
                     use_ema=args.use_ema, temperature=args.temperature)
+                # ====================================================================
+                # FIXED: Candidate Selection and Environment Step
+                # ====================================================================
 
                 with torch.no_grad():
                     q = critic_target.q_min(obs, act)
@@ -223,6 +264,13 @@ def pipeline(args):
         std_score = float(np.std(episode_rewards))
         mean_ep_reward = float(np.mean(raw_episode_rewards))
         print(f"EVAL_METRICS normalized_score={mean_score:.4f} normalized_score_std={std_score:.4f} episode_reward={mean_ep_reward:.2f}")
+
+        # Ceil, not round: an adaptive sampler averaging 10.5 evaluations must
+        # not report 10 and collect the full no-penalty credit reserved for a
+        # 10-step budget. Round-half-to-even would also floor an average of 0.5
+        # to zero. Constant-call samplers are unaffected.
+        measured_nfe = -(-_nfe["calls"] // max(_nfe["samples"], 1))
+        print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
 
     else:
         raise ValueError(f"Invalid mode: {args.mode}")

--- a/tasks/robo-diffusion-sampling-method/scripts/train_halfcheetah.sh
+++ b/tasks/robo-diffusion-sampling-method/scripts/train_halfcheetah.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=halfcheetah-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/tasks/robo-diffusion-sampling-method/scripts/train_hopper.sh
+++ b/tasks/robo-diffusion-sampling-method/scripts/train_hopper.sh
@@ -4,6 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=train seed=$SEED gradient_steps=300000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=hopper-medium-v2 mode=inference seed=$SEED ckpt=300000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-# Emit NFE so the score can penalize methods that need many sampling steps.
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/tasks/robo-diffusion-sampling-method/scripts/train_walker2d.sh
+++ b/tasks/robo-diffusion-sampling-method/scripts/train_walker2d.sh
@@ -4,5 +4,3 @@ cd /workspace/CleanDiffuser
 SEED=${SEED:-42}
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=train seed=$SEED gradient_steps=100000 batch_size=256 log_interval=1000 save_interval=50000
 python pipelines/custom_sampling_method.py task=walker2d-medium-v2 mode=inference seed=$SEED ckpt=100000 num_episodes=3 num_envs=50 num_candidates=50 use_ema=True
-NFE=$(grep "^sampling_steps:" /workspace/CleanDiffuser/configs/custom/mujoco/mujoco.yaml | awk '{print $2}')
-echo "NFE_METRICS sampling_steps=${NFE}"

--- a/tasks/robo-diffusion-sampling-method/task_description.md
+++ b/tasks/robo-diffusion-sampling-method/task_description.md
@@ -3,7 +3,7 @@
 ## Objective
 Design a single efficient diffusion sampler for a fixed DQL-style diffusion policy, maximizing D4RL MuJoCo return at low inference NFE (number of function evaluations).
 
-This task is deliberately about inference-time sampler choice, not policy learning, guidance, or trajectory planning. The trained actor / critic, dataset, environment list, seeds, and evaluation loop are fixed.
+This task is deliberately about the inference-time reverse process, not policy learning, guidance, or trajectory planning. The trained actor / critic, dataset, environment list, seeds, and evaluation loop are fixed.
 
 ## Background
 A diffusion policy's wall-clock inference cost is dominated by the number of reverse-process steps. Different ODE / SDE solvers reach a given sample quality at different NFE budgets:
@@ -14,15 +14,16 @@ A diffusion policy's wall-clock inference cost is dominated by the number of rev
 The setup builds on **CleanDiffuser** (Dong et al., NeurIPS 2024, arXiv:2406.09509) and the underlying actor is a DQL-style diffusion policy (Wang et al., ICLR 2023, arXiv:2208.06193) trained on **D4RL** (Fu et al., 2020, arXiv:2004.07219).
 
 ## What You Can Modify
-- `solver` in `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`
-- `sampling_steps` in the same YAML file
+- The **sampling algorithm itself** — the `EDITABLE REGION: Sampling Algorithm` block in `CleanDiffuser/pipelines/custom_sampling_method.py`, which turns a prior and an observation into actions. The default delegates to CleanDiffuser's built-in solvers; you may instead write the reverse process yourself, calling the denoiser (`actor.model_ema["diffusion"]`) directly with whatever discretization, step schedule, order or correction you want.
+- `solver` and `sampling_steps` in `CleanDiffuser/configs/custom/mujoco/mujoco.yaml`, which drive the default implementation.
 
 ## What Is Fixed
-- The pipeline code, model architecture, critic, and training objective
+- The actor and critic architectures, the training objective and the training loop
 - `diffusion_steps`, training budgets, checkpoint selection, and EMA use
-- D4RL environment names, seeds, and vectorized evaluation
+- Candidate selection, D4RL environment names, seeds, and vectorized evaluation
 
-The score's NFE term is read from the same `sampling_steps` field passed to CleanDiffuser's sampler. Custom pipeline-code samplers are intentionally out of scope here because they would decouple true NFE from the reported score column.
+## How NFE Is Counted
+NFE is **measured, not declared**: a forward hook on the denoiser counts real network evaluations during evaluation and reports the average per action sample. Writing your own reverse process is therefore in scope — a sampler that spends 40 evaluations is scored as 40 no matter what any config field says, and one that reaches the same return in 10 is scored as 10.
 
 ## Evaluation
 Evaluated on three D4RL MuJoCo environments:


### PR DESCRIPTION
## The problem

The task is named *Sampling Algorithm Design* and its objective says "design a single efficient diffusion sampler". What the agent could actually change was two YAML values:

```yaml
solver: ddpm          # line 15
sampling_steps: 100   # line 17
```

That is a selection among CleanDiffuser's built-in solvers, not an implementation. Every other task in this family opens code — the sibling `robo-diffusion-guidance` declares four editable regions inside its pipeline. And the scaffold here already carried

```python
# EDITABLE REGION: Policy Algorithm (lines 40-205)
```

while `config.json` declared that same file `"edit": []`. So this was a half-finished migration, not a deliberate design.

The reason given for the lockdown was real, though:

> Custom pipeline-code samplers are intentionally out of scope here because they would decouple true NFE from the reported score column.

The score's efficiency term came from the eval script doing `grep "^sampling_steps:" … | awk '{print $2}'`. Open the code with that in place and a hand-written sampler could spend 100 evaluations while reporting 10.

## The fix: measure NFE instead of forbidding code

A forward hook on the denoiser counts real network evaluations during evaluation, and the pipeline reports the average per action sample:

```python
_nfe = {"calls": 0, "samples": 0}
def _count_nfe(_module, _inputs, _output):
    _nfe["calls"] += 1
for _m in (actor.model, actor.model_ema):
    _m["diffusion"].register_forward_hook(_count_nfe)
...
measured_nfe = int(round(_nfe["calls"] / max(_nfe["samples"], 1)))
print(f"NFE_METRICS sampling_steps={measured_nfe}", flush=True)
```

The counter, the per-sample denominator and the reporting sit outside the editable range, and the reported value is `ceil`ed so an adaptive sampler averaging 10.5 evaluations reports 11 rather than collecting the credit reserved for a 10-step budget.

To be precise about what this does and does not buy: it removes the *decoupling* between the declared and the actual cost, so an honest submission is scored on what it spends. It is **not** tamper-proof, and cannot be — the agent's code runs in the same process, so it can clear the hook, call `.forward()` directly, or mutate the counter. That is the same exposure every other task in this benchmark already has, since the editable file is imported by the process whose stdout the parser scrapes; this task was the one exception only because it had no code surface at all. Making it a real implementation task necessarily brings it into the same regime as the other 139.

With the measurement honest, the reverse process opens up. The editable region (`213–235`) hands the agent the denoiser and the noise schedule and asks for actions; its default body is the previous `actor.sample(...)` call, so an agent that changes nothing behaves exactly as before. Training, candidate selection, the environments and the evaluation loop stay fixed, as the description always promised.

## Existing baseline numbers are unaffected

Established statically, not by re-running:

- the denoising loop in `cleandiffuser/diffusion/diffusionsde.py` calls `guided_sampling` **once per iteration** for every solver — the `solver ==` branch only changes the update formula, and multistep DPM-Solver++ reuses its buffer rather than taking extra evaluations;
- the pipeline samples with `w_cfg=1.0`, and `classifier_free_guidance` takes its two-call path only when `w != 0.0 and w != 1.0`, so `1.0` lands on the single-call `else`.

Measured NFE therefore equals `sample_steps` exactly — the same number the eval script used to grep. The three baselines keep their YAML-only edit ops, so their training and inference are byte-identical and their leaderboard rows stay valid.

## Harbor bundle

Re-rendered, but `instruction.md` is **hand-patched rather than replaced**. A fresh render brings back the auto-generated `## How You Will Be Evaluated` block, the whole `## Evaluation` section including the score formula and the NFE penalty table, the dataset identity, and the pre-#39 "will cause your submission to score zero" wording — all of which the repo-wide cleanup had removed. The shipped file is the base and only the deltas from this change are applied; verified afterwards that the prose-level leak profile is identical to `main`. `tests/mlsbench_src/` is likewise left alone — the render would have pulled in unrelated drift.

Verified before committing:

| check | result |
|---|---|
| scaffold ≡ `tests/meta/pristine` | identical bytes |
| `pristine_manifest.json` hash | correct for the new bytes |
| editable range `213–235` | lands on the sampling block, default implementation inside |
| lines quoted in `instruction.md` | all match the scaffold |
| eval scripts | no `grep sampling_steps` left; pipeline reports the measured value |
| `dataset.toml` | this task's digest regenerated |

## Notes

- The five agent runs already on this task's leaderboard were produced against the YAML-only surface and are not comparable to future runs. Left in place pending a decision on re-running.
- `dataset.toml` here updates only this task's entry. #70 regenerates all 140 (every committed digest on `main` is stale); if that merges first this line just gets regenerated again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
