### PR TITLE
Harden the IsaacGym sm_90 PhysX path against pre-570 user-space drivers

### DIFF
--- a/harbor/tasks/dataset.toml
+++ b/harbor/tasks/dataset.toml
@@ -487,7 +487,7 @@ digest = "sha256:1134c5b087d55d1376210b2d1c1cae491b2e7743c449a33baadd185bc50ba8e
 
 [[tasks]]
 name = "mls-bench/robo-humanoid-sim2real-algo"
-digest = "sha256:65210b123d75eed66ba35123a4e3d76ff65b67940101160181c0daad40d35823"
+digest = "sha256:9949c4a031ab3846f1554e076a1c336d093ac5b816c7327e9e9047ffdd2c3b55"
 
 [[tasks]]
 name = "mls-bench/robomimic-bc-loss"

--- a/harbor/tasks/dataset.toml
+++ b/harbor/tasks/dataset.toml
@@ -487,7 +487,7 @@ digest = "sha256:1134c5b087d55d1376210b2d1c1cae491b2e7743c449a33baadd185bc50ba8e
 
 [[tasks]]
 name = "mls-bench/robo-humanoid-sim2real-algo"
-digest = "sha256:a12917a3aa4707c1a42300f9ac949255c2c887388ef8ac32b78558610d13470c"
+digest = "sha256:65210b123d75eed66ba35123a4e3d76ff65b67940101160181c0daad40d35823"
 
 [[tasks]]
 name = "mls-bench/robomimic-bc-loss"

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_diverse.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_diverse.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on diverse mixed commands (forward/backward, lateral, turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for diverse commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_diverse.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_diverse.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_forward.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_forward.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_forward.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_forward.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on forward-only commands (minimal lateral/turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for forward-only commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_highspeed.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_highspeed.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_highspeed.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_highspeed.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on high-speed commands (stress test)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for high-speed commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_sim2sim_diverse.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/eval_sim2sim_diverse.py
@@ -4,6 +4,25 @@
 import os
 import sys
 
+# --- Thread-oversubscription guard (MUST run before numpy/scipy/torch/mujoco import) ---
+# This eval is CPU-bound (MuJoCo sim loop + small torch policy forward). Each numerical
+# backend (OpenMP, MKL, OpenBLAS, numexpr, torch) otherwise spins up ~ncores threads.
+# When several evals share a node — or even a single eval on a many-core box — these
+# pools oversubscribe the CPU, thrash caches, and slow the wall clock far beyond linear,
+# which is what caused the concurrent evals to time out. Cap thread pools to a small
+# number here. Every cap is idempotent and env-overridable: if the caller already set a
+# value (e.g. via the scheduler) we leave it untouched. BLAS env vars are honored only
+# at import time, so they MUST be set before importing numpy/torch below.
+_DEFAULT_EVAL_THREADS = os.getenv("MLSB_EVAL_THREADS", "8")
+for _var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_var, _DEFAULT_EVAL_THREADS)
+
 # IMPORTANT: isaacgym MUST be imported before torch (Isaac Gym's gymdeps enforces this).
 # So we do the humanoid.envs import (which transitively imports isaacgym) up front,
 # before any module that pulls in torch.
@@ -19,6 +38,14 @@ import numpy as np
 import mujoco
 from scipy.spatial.transform import Rotation as R
 import torch
+
+# Cap torch's intra-op CPU thread pool to match the BLAS caps set above. torch reads
+# OMP_NUM_THREADS at init, but we set it explicitly so the cap holds regardless of how
+# torch was built or whether the env var propagated. Honors an explicit override.
+try:
+    torch.set_num_threads(int(os.environ.get("OMP_NUM_THREADS", _DEFAULT_EVAL_THREADS)))
+except Exception:
+    pass
 
 
 def quaternion_to_euler_array(quat):

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/gpu_env_preflight.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/gpu_env_preflight.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# GPU environment preflight for the IsaacGym legs of this task.
+#
+# Why this exists
+# ---------------
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
+# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
+# created. That JIT lives in the *user-space* driver (libcuda +
+# libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
+# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
+# reported, and what a second site independently confirmed. The kernel driver
+# does not have to be touched: a >= 570 user-space CUDA forward-compatibility
+# stack inside the container is enough, and a host on 535/550 keeps its driver.
+#
+# So before the run we:
+#   1. print one greppable line describing GPU / driver / PhysX device code,
+#   2. transparently activate a bundled >= 570 forward-compat stack when the
+#      user-space driver is too old for the GPU it is driving, and
+#   3. when we cannot fix it, say exactly what to do — instead of letting the run
+#      die later in a bare `Segmentation fault` inside create_sim.
+#
+# This file is *sourced*, not executed, so the LD_LIBRARY_PATH it exports reaches
+# the python child. Everything here is best-effort: it must never abort the run
+# (callers use `set -e`), and a healthy node pays one short probe.
+#
+# Knobs:
+#   MLSBENCH_SKIP_GPU_PREFLIGHT=1            skip entirely
+#   MLSBENCH_CUDA_COMPAT_DIR=<dir>           forward-compat dir to try first
+#   MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER=<maj>  override the 570 threshold
+
+_mls_pf_min_driver="${MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER:-570}"
+_mls_pf_physx_so="${ISAACGYM_PHYSX_SO:-/opt/isaacgym/python/isaacgym/_bindings/linux-x86_64/libPhysXGpu_64.so}"
+
+_mls_pf_python() {
+    command -v python3 2>/dev/null || command -v python 2>/dev/null
+}
+
+# Ask the driver itself, via ctypes, two things at once:
+#   - the realpath of the libcuda.so.1 this process actually loads
+#   - the compute capability of the first visible device
+# Prints "<libcuda-realpath>|<compute-cap>"; either field may be empty. A
+# non-empty compute cap also proves cuInit() succeeded, so this doubles as the
+# "is this driver stack usable" check after we swap LD_LIBRARY_PATH.
+_mls_pf_probe() {
+    local py="$1"
+    [ -n "$py" ] || return 0
+    "$py" - <<'PY' 2>/dev/null
+import ctypes, os
+
+path = ""
+cc = ""
+try:
+    lib = ctypes.CDLL("libcuda.so.1")
+except OSError:
+    lib = None
+if lib is not None:
+    try:
+        for line in open("/proc/self/maps"):
+            candidate = line.rstrip("\n").rsplit(" ", 1)[-1]
+            if "/libcuda.so." in candidate:
+                path = os.path.realpath(candidate)
+                break
+    except OSError:
+        pass
+    try:
+        if lib.cuInit(0) == 0:
+            dev = ctypes.c_int()
+            if lib.cuDeviceGet(ctypes.byref(dev), 0) == 0:
+                major, minor = ctypes.c_int(), ctypes.c_int()
+                # CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_{MAJOR,MINOR}
+                rc_major = lib.cuDeviceGetAttribute(ctypes.byref(major), 75, dev)
+                rc_minor = lib.cuDeviceGetAttribute(ctypes.byref(minor), 76, dev)
+                if rc_major == 0 and rc_minor == 0:
+                    cc = "%d.%d" % (major.value, minor.value)
+    except Exception:
+        pass
+print("%s|%s" % (path, cc))
+PY
+}
+
+# ".../libcuda.so.570.211.01" -> "570.211.01"; anything unversioned -> ""
+_mls_pf_driver_version() {
+    local base="${1##*/}"
+    case "$base" in
+        libcuda.so.[0-9]*.[0-9]*) echo "${base#libcuda.so.}" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Which device code does this PhysX binary actually carry? On Hopper the answer
+# is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
+# which is the second failure mode seen in #47 (community IsaacGym images ship a
+# stripped libPhysXGpu with its PTX payload pruned out).
+_mls_pf_physx_inventory() {
+    local cc="$1" so="$_mls_pf_physx_so" sass ptx want
+    [ -f "$so" ] || return 0
+    command -v cuobjdump >/dev/null 2>&1 || return 0
+    sass="$(timeout 60 cuobjdump --list-elf "$so" 2>/dev/null | grep -o 'sm_[0-9]\+' | sort -u | paste -sd, -)"
+    ptx="$(timeout 60 cuobjdump --list-ptx "$so" 2>/dev/null | grep -c '\.ptx')"
+    echo "GPU_ENV_PREFLIGHT physx sass=${sass:-none} ptx_payloads=${ptx:-0} so=$so"
+    want="sm_${cc%%.*}${cc#*.}"
+    if [ "${ptx:-0}" -eq 0 ] && ! printf '%s' ",${sass}," | grep -q ",${want},"; then
+        cat >&2 <<EOF
+GPU_ENV_PREFLIGHT ERROR: $so carries neither a ${want} cubin nor any PTX, so it
+cannot run on this GPU by any driver path. This is a pruned/stripped IsaacGym
+copy, not a driver problem — restore the stock Preview 4 binary (the one
+vendor/data_scripts/humanoid-gym/prepare_isaacgym.py downloads) and re-run.
+EOF
+    fi
+}
+
+# Prepend the first usable >= min_driver forward-compat directory to
+# LD_LIBRARY_PATH, verifying by re-probing that the new libcuda is the one that
+# actually loads *and* that it initialises (forward compat is a data-center-GPU
+# feature; on other hardware it loads but cuInit fails, so we must roll back).
+_mls_pf_activate_compat() {
+    local py="$1" from="$2" dir saved cand_ver cand_major probe now
+    saved="${LD_LIBRARY_PATH:-}"
+    for dir in "${MLSBENCH_CUDA_COMPAT_DIR:-}" \
+               /opt/mlsbench/cuda-compat \
+               /usr/local/cuda-12.9/compat \
+               /usr/local/cuda-12.8/compat; do
+        [ -n "$dir" ] || continue
+        [ -e "$dir/libcuda.so.1" ] || continue
+        cand_ver="$(_mls_pf_driver_version "$(readlink -f "$dir/libcuda.so.1")")"
+        cand_major="${cand_ver%%.*}"
+        case "$cand_major" in ''|*[!0-9]*) continue ;; esac
+        [ "$cand_major" -ge "$_mls_pf_min_driver" ] || continue
+
+        export LD_LIBRARY_PATH="$dir${saved:+:$saved}"
+        probe="$(_mls_pf_probe "$py")"
+        now="$(_mls_pf_driver_version "${probe%%|*}")"
+        if [ "$now" = "$cand_ver" ] && [ -n "${probe#*|}" ]; then
+            echo "GPU_ENV_PREFLIGHT remediation=cuda-compat dir=$dir user_driver=${from:-unknown}->$now"
+            return 0
+        fi
+        echo "GPU_ENV_PREFLIGHT compat candidate $dir rejected (loaded='${now:-none}', cuInit=${probe#*|})" >&2
+        if [ -n "$saved" ]; then export LD_LIBRARY_PATH="$saved"; else unset LD_LIBRARY_PATH; fi
+    done
+    return 1
+}
+
+_mls_pf_report_unfixable() {
+    local cc="$1" udrv="$2" sm="sm_${1%%.*}${1#*.}"
+    cat >&2 <<EOF
+========================================================================
+GPU_ENV_PREFLIGHT WARNING: this container drives a ${sm} GPU with a
+user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
+
+IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
+to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
+older than ${_mls_pf_min_driver} are known to segfault inside that JIT
+(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+python traceback, and the run then scores 0.
+
+Any one of these fixes it:
+  * run on a host whose NVIDIA driver is >= ${_mls_pf_min_driver}; or
+  * keep the host driver where it is and upgrade only the container's
+    user-space driver, by mounting NVIDIA's cuda-compat package (>= 570,
+    e.g. cuda-compat-12-8) at /opt/mlsbench/cuda-compat:
+        docker run -v /path/to/compat:/opt/mlsbench/cuda-compat ...
+    or by pointing MLSBENCH_CUDA_COMPAT_DIR at wherever you unpacked it.
+    This preflight then activates it automatically; or
+  * re-pull the MLS-Bench humanoid-gym image, which bundles that directory,
+    so no mount is needed.
+
+Continuing anyway — the run may still work, or may segfault in create_sim.
+========================================================================
+EOF
+}
+
+_mls_gpu_env_preflight() {
+    [ "${MLSBENCH_SKIP_GPU_PREFLIGHT:-0}" = "1" ] && return 0
+
+    local py probe libcuda cc cc_major kdrv udrv udrv_major
+    py="$(_mls_pf_python)"
+    probe="$(_mls_pf_probe "$py")"
+    libcuda="${probe%%|*}"
+    cc="${probe#*|}"
+    kdrv="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    udrv="$(_mls_pf_driver_version "$libcuda")"
+    cc_major="${cc%%.*}"
+    udrv_major="${udrv%%.*}"
+
+    echo "GPU_ENV_PREFLIGHT compute_cap=${cc:-unknown} kernel_driver=${kdrv:-unknown} user_driver=${udrv:-unknown} libcuda=${libcuda:-not-loaded}"
+
+    # Everything below only matters on Hopper and newer, where PhysX has no
+    # native cubin and the PTX JIT is on the critical path.
+    case "$cc_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$cc_major" -ge 9 ] || return 0
+
+    _mls_pf_physx_inventory "$cc"
+
+    case "$udrv_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$udrv_major" -ge "$_mls_pf_min_driver" ] && return 0
+
+    _mls_pf_activate_compat "$py" "$udrv" || _mls_pf_report_unfixable "$cc" "$udrv"
+}
+
+_mls_gpu_env_preflight || true

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/gpu_env_preflight.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/gpu_env_preflight.sh
@@ -3,13 +3,14 @@
 #
 # Why this exists
 # ---------------
-# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
-# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest cubin is sm_80,
+# plus a PTX payload targeting sm_86. On a Hopper GPU (sm_90) there is no
 # matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
 # created. That JIT lives in the *user-space* driver (libcuda +
 # libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
-# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
-# reported, and what a second site independently confirmed. The kernel driver
+# segfault instead of emitting sm_90 code — MLS-Bench issue #59 has the gdb
+# backtrace landing inside libnvidia-ptxjitcompiler on driver 535.161.08, and a
+# second site independently confirmed the same. The kernel driver
 # does not have to be touched: a >= 570 user-space CUDA forward-compatibility
 # stack inside the container is enough, and a host on 535/550 keeps its driver.
 #
@@ -90,8 +91,8 @@ _mls_pf_driver_version() {
 
 # Which device code does this PhysX binary actually carry? On Hopper the answer
 # is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
-# which is the second failure mode seen in #47 (community IsaacGym images ship a
-# stripped libPhysXGpu with its PTX payload pruned out).
+# which is the other failure mode, diagnosed in #47: community IsaacGym images
+# ship a stripped libPhysXGpu with its PTX payload pruned out.
 _mls_pf_physx_inventory() {
     local cc="$1" so="$_mls_pf_physx_so" sass ptx want
     [ -f "$so" ] || return 0
@@ -151,7 +152,7 @@ user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
 IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
 to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
 older than ${_mls_pf_min_driver} are known to segfault inside that JIT
-(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+(MLS-Bench issue #59): it surfaces as a bare "Segmentation fault" with no
 python traceback, and the run then scores 0.
 
 Any one of these fixes it:

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/train.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/train.sh
@@ -2,6 +2,12 @@
 # Train humanoid locomotion policy with custom algorithm and export JIT policy
 set -e
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Use SEED (injected by MLS-Bench framework) for reproducibility

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/train.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/eval/scripts/train.sh
@@ -4,7 +4,7 @@ set -e
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_diverse.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_diverse.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on diverse mixed commands (forward/backward, lateral, turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for diverse commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_diverse.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_diverse.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_forward.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_forward.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_forward.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_forward.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on forward-only commands (minimal lateral/turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for forward-only commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_highspeed.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_highspeed.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_highspeed.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_highspeed.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on high-speed commands (stress test)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for high-speed commands

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_sim2sim_diverse.py
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/eval_sim2sim_diverse.py
@@ -4,6 +4,25 @@
 import os
 import sys
 
+# --- Thread-oversubscription guard (MUST run before numpy/scipy/torch/mujoco import) ---
+# This eval is CPU-bound (MuJoCo sim loop + small torch policy forward). Each numerical
+# backend (OpenMP, MKL, OpenBLAS, numexpr, torch) otherwise spins up ~ncores threads.
+# When several evals share a node — or even a single eval on a many-core box — these
+# pools oversubscribe the CPU, thrash caches, and slow the wall clock far beyond linear,
+# which is what caused the concurrent evals to time out. Cap thread pools to a small
+# number here. Every cap is idempotent and env-overridable: if the caller already set a
+# value (e.g. via the scheduler) we leave it untouched. BLAS env vars are honored only
+# at import time, so they MUST be set before importing numpy/torch below.
+_DEFAULT_EVAL_THREADS = os.getenv("MLSB_EVAL_THREADS", "8")
+for _var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_var, _DEFAULT_EVAL_THREADS)
+
 # IMPORTANT: isaacgym MUST be imported before torch (Isaac Gym's gymdeps enforces this).
 # So we do the humanoid.envs import (which transitively imports isaacgym) up front,
 # before any module that pulls in torch.
@@ -19,6 +38,14 @@ import numpy as np
 import mujoco
 from scipy.spatial.transform import Rotation as R
 import torch
+
+# Cap torch's intra-op CPU thread pool to match the BLAS caps set above. torch reads
+# OMP_NUM_THREADS at init, but we set it explicitly so the cap holds regardless of how
+# torch was built or whether the env var propagated. Honors an explicit override.
+try:
+    torch.set_num_threads(int(os.environ.get("OMP_NUM_THREADS", _DEFAULT_EVAL_THREADS)))
+except Exception:
+    pass
 
 
 def quaternion_to_euler_array(quat):

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/gpu_env_preflight.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/gpu_env_preflight.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# GPU environment preflight for the IsaacGym legs of this task.
+#
+# Why this exists
+# ---------------
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
+# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
+# created. That JIT lives in the *user-space* driver (libcuda +
+# libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
+# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
+# reported, and what a second site independently confirmed. The kernel driver
+# does not have to be touched: a >= 570 user-space CUDA forward-compatibility
+# stack inside the container is enough, and a host on 535/550 keeps its driver.
+#
+# So before the run we:
+#   1. print one greppable line describing GPU / driver / PhysX device code,
+#   2. transparently activate a bundled >= 570 forward-compat stack when the
+#      user-space driver is too old for the GPU it is driving, and
+#   3. when we cannot fix it, say exactly what to do — instead of letting the run
+#      die later in a bare `Segmentation fault` inside create_sim.
+#
+# This file is *sourced*, not executed, so the LD_LIBRARY_PATH it exports reaches
+# the python child. Everything here is best-effort: it must never abort the run
+# (callers use `set -e`), and a healthy node pays one short probe.
+#
+# Knobs:
+#   MLSBENCH_SKIP_GPU_PREFLIGHT=1            skip entirely
+#   MLSBENCH_CUDA_COMPAT_DIR=<dir>           forward-compat dir to try first
+#   MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER=<maj>  override the 570 threshold
+
+_mls_pf_min_driver="${MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER:-570}"
+_mls_pf_physx_so="${ISAACGYM_PHYSX_SO:-/opt/isaacgym/python/isaacgym/_bindings/linux-x86_64/libPhysXGpu_64.so}"
+
+_mls_pf_python() {
+    command -v python3 2>/dev/null || command -v python 2>/dev/null
+}
+
+# Ask the driver itself, via ctypes, two things at once:
+#   - the realpath of the libcuda.so.1 this process actually loads
+#   - the compute capability of the first visible device
+# Prints "<libcuda-realpath>|<compute-cap>"; either field may be empty. A
+# non-empty compute cap also proves cuInit() succeeded, so this doubles as the
+# "is this driver stack usable" check after we swap LD_LIBRARY_PATH.
+_mls_pf_probe() {
+    local py="$1"
+    [ -n "$py" ] || return 0
+    "$py" - <<'PY' 2>/dev/null
+import ctypes, os
+
+path = ""
+cc = ""
+try:
+    lib = ctypes.CDLL("libcuda.so.1")
+except OSError:
+    lib = None
+if lib is not None:
+    try:
+        for line in open("/proc/self/maps"):
+            candidate = line.rstrip("\n").rsplit(" ", 1)[-1]
+            if "/libcuda.so." in candidate:
+                path = os.path.realpath(candidate)
+                break
+    except OSError:
+        pass
+    try:
+        if lib.cuInit(0) == 0:
+            dev = ctypes.c_int()
+            if lib.cuDeviceGet(ctypes.byref(dev), 0) == 0:
+                major, minor = ctypes.c_int(), ctypes.c_int()
+                # CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_{MAJOR,MINOR}
+                rc_major = lib.cuDeviceGetAttribute(ctypes.byref(major), 75, dev)
+                rc_minor = lib.cuDeviceGetAttribute(ctypes.byref(minor), 76, dev)
+                if rc_major == 0 and rc_minor == 0:
+                    cc = "%d.%d" % (major.value, minor.value)
+    except Exception:
+        pass
+print("%s|%s" % (path, cc))
+PY
+}
+
+# ".../libcuda.so.570.211.01" -> "570.211.01"; anything unversioned -> ""
+_mls_pf_driver_version() {
+    local base="${1##*/}"
+    case "$base" in
+        libcuda.so.[0-9]*.[0-9]*) echo "${base#libcuda.so.}" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Which device code does this PhysX binary actually carry? On Hopper the answer
+# is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
+# which is the second failure mode seen in #47 (community IsaacGym images ship a
+# stripped libPhysXGpu with its PTX payload pruned out).
+_mls_pf_physx_inventory() {
+    local cc="$1" so="$_mls_pf_physx_so" sass ptx want
+    [ -f "$so" ] || return 0
+    command -v cuobjdump >/dev/null 2>&1 || return 0
+    sass="$(timeout 60 cuobjdump --list-elf "$so" 2>/dev/null | grep -o 'sm_[0-9]\+' | sort -u | paste -sd, -)"
+    ptx="$(timeout 60 cuobjdump --list-ptx "$so" 2>/dev/null | grep -c '\.ptx')"
+    echo "GPU_ENV_PREFLIGHT physx sass=${sass:-none} ptx_payloads=${ptx:-0} so=$so"
+    want="sm_${cc%%.*}${cc#*.}"
+    if [ "${ptx:-0}" -eq 0 ] && ! printf '%s' ",${sass}," | grep -q ",${want},"; then
+        cat >&2 <<EOF
+GPU_ENV_PREFLIGHT ERROR: $so carries neither a ${want} cubin nor any PTX, so it
+cannot run on this GPU by any driver path. This is a pruned/stripped IsaacGym
+copy, not a driver problem — restore the stock Preview 4 binary (the one
+vendor/data_scripts/humanoid-gym/prepare_isaacgym.py downloads) and re-run.
+EOF
+    fi
+}
+
+# Prepend the first usable >= min_driver forward-compat directory to
+# LD_LIBRARY_PATH, verifying by re-probing that the new libcuda is the one that
+# actually loads *and* that it initialises (forward compat is a data-center-GPU
+# feature; on other hardware it loads but cuInit fails, so we must roll back).
+_mls_pf_activate_compat() {
+    local py="$1" from="$2" dir saved cand_ver cand_major probe now
+    saved="${LD_LIBRARY_PATH:-}"
+    for dir in "${MLSBENCH_CUDA_COMPAT_DIR:-}" \
+               /opt/mlsbench/cuda-compat \
+               /usr/local/cuda-12.9/compat \
+               /usr/local/cuda-12.8/compat; do
+        [ -n "$dir" ] || continue
+        [ -e "$dir/libcuda.so.1" ] || continue
+        cand_ver="$(_mls_pf_driver_version "$(readlink -f "$dir/libcuda.so.1")")"
+        cand_major="${cand_ver%%.*}"
+        case "$cand_major" in ''|*[!0-9]*) continue ;; esac
+        [ "$cand_major" -ge "$_mls_pf_min_driver" ] || continue
+
+        export LD_LIBRARY_PATH="$dir${saved:+:$saved}"
+        probe="$(_mls_pf_probe "$py")"
+        now="$(_mls_pf_driver_version "${probe%%|*}")"
+        if [ "$now" = "$cand_ver" ] && [ -n "${probe#*|}" ]; then
+            echo "GPU_ENV_PREFLIGHT remediation=cuda-compat dir=$dir user_driver=${from:-unknown}->$now"
+            return 0
+        fi
+        echo "GPU_ENV_PREFLIGHT compat candidate $dir rejected (loaded='${now:-none}', cuInit=${probe#*|})" >&2
+        if [ -n "$saved" ]; then export LD_LIBRARY_PATH="$saved"; else unset LD_LIBRARY_PATH; fi
+    done
+    return 1
+}
+
+_mls_pf_report_unfixable() {
+    local cc="$1" udrv="$2" sm="sm_${1%%.*}${1#*.}"
+    cat >&2 <<EOF
+========================================================================
+GPU_ENV_PREFLIGHT WARNING: this container drives a ${sm} GPU with a
+user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
+
+IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
+to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
+older than ${_mls_pf_min_driver} are known to segfault inside that JIT
+(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+python traceback, and the run then scores 0.
+
+Any one of these fixes it:
+  * run on a host whose NVIDIA driver is >= ${_mls_pf_min_driver}; or
+  * keep the host driver where it is and upgrade only the container's
+    user-space driver, by mounting NVIDIA's cuda-compat package (>= 570,
+    e.g. cuda-compat-12-8) at /opt/mlsbench/cuda-compat:
+        docker run -v /path/to/compat:/opt/mlsbench/cuda-compat ...
+    or by pointing MLSBENCH_CUDA_COMPAT_DIR at wherever you unpacked it.
+    This preflight then activates it automatically; or
+  * re-pull the MLS-Bench humanoid-gym image, which bundles that directory,
+    so no mount is needed.
+
+Continuing anyway — the run may still work, or may segfault in create_sim.
+========================================================================
+EOF
+}
+
+_mls_gpu_env_preflight() {
+    [ "${MLSBENCH_SKIP_GPU_PREFLIGHT:-0}" = "1" ] && return 0
+
+    local py probe libcuda cc cc_major kdrv udrv udrv_major
+    py="$(_mls_pf_python)"
+    probe="$(_mls_pf_probe "$py")"
+    libcuda="${probe%%|*}"
+    cc="${probe#*|}"
+    kdrv="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    udrv="$(_mls_pf_driver_version "$libcuda")"
+    cc_major="${cc%%.*}"
+    udrv_major="${udrv%%.*}"
+
+    echo "GPU_ENV_PREFLIGHT compute_cap=${cc:-unknown} kernel_driver=${kdrv:-unknown} user_driver=${udrv:-unknown} libcuda=${libcuda:-not-loaded}"
+
+    # Everything below only matters on Hopper and newer, where PhysX has no
+    # native cubin and the PTX JIT is on the critical path.
+    case "$cc_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$cc_major" -ge 9 ] || return 0
+
+    _mls_pf_physx_inventory "$cc"
+
+    case "$udrv_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$udrv_major" -ge "$_mls_pf_min_driver" ] && return 0
+
+    _mls_pf_activate_compat "$py" "$udrv" || _mls_pf_report_unfixable "$cc" "$udrv"
+}
+
+_mls_gpu_env_preflight || true

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/gpu_env_preflight.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/gpu_env_preflight.sh
@@ -3,13 +3,14 @@
 #
 # Why this exists
 # ---------------
-# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
-# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest cubin is sm_80,
+# plus a PTX payload targeting sm_86. On a Hopper GPU (sm_90) there is no
 # matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
 # created. That JIT lives in the *user-space* driver (libcuda +
 # libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
-# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
-# reported, and what a second site independently confirmed. The kernel driver
+# segfault instead of emitting sm_90 code — MLS-Bench issue #59 has the gdb
+# backtrace landing inside libnvidia-ptxjitcompiler on driver 535.161.08, and a
+# second site independently confirmed the same. The kernel driver
 # does not have to be touched: a >= 570 user-space CUDA forward-compatibility
 # stack inside the container is enough, and a host on 535/550 keeps its driver.
 #
@@ -90,8 +91,8 @@ _mls_pf_driver_version() {
 
 # Which device code does this PhysX binary actually carry? On Hopper the answer
 # is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
-# which is the second failure mode seen in #47 (community IsaacGym images ship a
-# stripped libPhysXGpu with its PTX payload pruned out).
+# which is the other failure mode, diagnosed in #47: community IsaacGym images
+# ship a stripped libPhysXGpu with its PTX payload pruned out.
 _mls_pf_physx_inventory() {
     local cc="$1" so="$_mls_pf_physx_so" sass ptx want
     [ -f "$so" ] || return 0
@@ -151,7 +152,7 @@ user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
 IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
 to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
 older than ${_mls_pf_min_driver} are known to segfault inside that JIT
-(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+(MLS-Bench issue #59): it surfaces as a bare "Segmentation fault" with no
 python traceback, and the run then scores 0.
 
 Any one of these fixes it:

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/train.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/train.sh
@@ -2,6 +2,12 @@
 # Train humanoid locomotion policy with custom algorithm and export JIT policy
 set -e
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Use SEED (injected by MLS-Bench framework) for reproducibility

--- a/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/train.sh
+++ b/harbor/tasks/mls-bench__robo-humanoid-sim2real-algo/tests/meta/scripts/train.sh
@@ -4,7 +4,7 @@ set -e
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/harbor_adapter/README.md
+++ b/harbor_adapter/README.md
@@ -144,6 +144,28 @@ environment:
 Switch to `type: docker` if you don't need GPU and don't want to install
 this adapter as a package.
 
+### IsaacGym on Hopper needs a >= 570 user-space driver
+
+`mls-bench__robo-humanoid-sim2real-algo` runs IsaacGym Preview 4, whose
+`libPhysXGpu_64.so` tops out at `sm_86` SASS plus a `compute_86` PTX payload.
+On `sm_90` the driver has to JIT that PTX at `create_sim`, and user-space
+driver branches older than 570 segfault doing it — a bare `Segmentation fault`
+with no python traceback, scored 0 (issue #47).
+
+Only the *user-space* driver matters; the host kernel driver can stay on
+535/550. The task's `scripts/gpu_env_preflight.sh` (rendered into
+`tests/eval/scripts/`) logs a `GPU_ENV_PREFLIGHT` line with the GPU compute
+capability, both driver versions and the PhysX device-code inventory, and on
+`sm_90`+ with a pre-570 user-space driver it activates a CUDA
+forward-compatibility stack from `/opt/mlsbench/cuda-compat` — baked into the
+`humanoid-gym` base image — rolling back if the swapped `libcuda` does not load
+or `cuInit` fails. Operators running an older base image can supply their own:
+
+```bash
+docker run -v /path/to/cuda-compat-12-8:/opt/mlsbench/cuda-compat ...
+# or point MLSBENCH_CUDA_COMPAT_DIR at it
+```
+
 ## Baseline picking & oracle solve
 
 `solution/solve.sh` is an oracle that replays the strongest declared

--- a/harbor_adapter/README.md
+++ b/harbor_adapter/README.md
@@ -147,10 +147,10 @@ this adapter as a package.
 ### IsaacGym on Hopper needs a >= 570 user-space driver
 
 `mls-bench__robo-humanoid-sim2real-algo` runs IsaacGym Preview 4, whose
-`libPhysXGpu_64.so` tops out at `sm_86` SASS plus a `compute_86` PTX payload.
+`libPhysXGpu_64.so` tops out at an `sm_80` cubin plus PTX targeting `sm_86`.
 On `sm_90` the driver has to JIT that PTX at `create_sim`, and user-space
 driver branches older than 570 segfault doing it — a bare `Segmentation fault`
-with no python traceback, scored 0 (issue #47).
+with no python traceback, scored 0 (issue #59).
 
 Only the *user-space* driver matters; the host kernel driver can stay on
 535/550. The task's `scripts/gpu_env_preflight.sh` (rendered into

--- a/harbor_adapter/tests/test_adapter.py
+++ b/harbor_adapter/tests/test_adapter.py
@@ -12,6 +12,7 @@ if str(ADAPTER_SRC) not in sys.path:
 
 from mls_bench.adapter import (  # noqa: E402
     MAX_PARALLEL_GPUS,
+    WAVE_GRACE_SEC,
     MlsBenchRoot,
     _apply_ops_to_text,
     _baseline_sections,
@@ -511,11 +512,16 @@ def test_verifier_timeout_pays_for_each_serialized_wave():
     ])
     gpus = _resources({}, config)["gpus"]
 
-    # 2 waves x 4h + 30min slack + 120s per (test_cmd, seed).
-    assert _verifier_timeout_sec(config, gpus) == 2 * 4 * 3600 + 30 * 60 + 120 * 3
+    # 2 waves x (4h + the grace score_task.py grants each wave), + 30min
+    # slack + 120s per (test_cmd, seed).
+    assert _verifier_timeout_sec(config, gpus) == (
+        2 * (4 * 3600 + WAVE_GRACE_SEC) + 30 * 60 + 120 * 3
+    )
 
-    # With enough GPUs for the whole group, the old single-wave budget stands.
-    assert _verifier_timeout_sec(config, 12) == 4 * 3600 + 30 * 60 + 120 * 3
+    # With enough GPUs for the whole group it collapses to a single wave.
+    assert _verifier_timeout_sec(config, 12) == (
+        4 * 3600 + WAVE_GRACE_SEC + 30 * 60 + 120 * 3
+    )
 
 
 def test_verifier_timeout_unchanged_for_cpu_only_tasks():
@@ -524,7 +530,10 @@ def test_verifier_timeout_unchanged_for_cpu_only_tasks():
         {"label": "b", "group": 2, "time": "1:00:00", "compute": 0},
     ]}
 
-    assert _verifier_timeout_sec(config, 0) == 90 * 60 + 30 * 60 + 120 * 2
+    # One wave per group, each charged its own deadline plus grace.
+    assert _verifier_timeout_sec(config, 0) == (
+        30 * 60 + WAVE_GRACE_SEC + 60 * 60 + WAVE_GRACE_SEC + 30 * 60 + 120 * 2
+    )
 
 
 def test_gpu_serialization_note_only_for_capped_tasks():

--- a/tasks/robo-humanoid-sim2real-algo/README.md
+++ b/tasks/robo-humanoid-sim2real-algo/README.md
@@ -27,6 +27,42 @@ The task uses a sim2sim evaluation protocol:
 - `humanoid-gym/humanoid/algo/ppo/ppo.py` - Original PPO implementation
 - `humanoid-gym/humanoid/algo/ppo/rollout_storage.py` - Original rollout storage implementation
 
+## Runtime requirement: NVIDIA driver >= 570 on Hopper and newer
+
+IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
+`sm_86`, plus a `compute_86` PTX payload. On a Hopper GPU (`sm_90`) there is no
+matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
+created. That JIT runs in the **user-space** driver, and 5xx user-space branches
+older than 570 are known to segfault in it: the run dies with a bare
+`Segmentation fault` inside `create_sim`, no python traceback, and scores 0
+([issue #47](https://github.com/Imbernoulli/MLS-Bench/issues/47)).
+
+Only the *user-space* driver has to move — the host's kernel driver can stay on
+535/550. `scripts/gpu_env_preflight.sh`, sourced by every script in this task,
+handles it:
+
+- it logs one `GPU_ENV_PREFLIGHT` line with the GPU's compute capability, the
+  kernel driver, the user-space driver actually loaded, and the device code
+  present in `libPhysXGpu_64.so`;
+- if the GPU is `sm_90`+ and the user-space driver is older than 570, it
+  activates a CUDA forward-compatibility stack (`/opt/mlsbench/cuda-compat`,
+  baked into the `humanoid-gym` image from NVIDIA's `cuda-compat-12-8`), after
+  verifying that the new `libcuda` really is the one that loads and that
+  `cuInit` succeeds — forward compat is a data-center-GPU feature, so it rolls
+  back cleanly on hardware where it does not apply;
+- if it cannot repair the stack, it prints what to do instead of letting the run
+  segfault silently.
+
+Overrides: `MLSBENCH_CUDA_COMPAT_DIR` (use your own compat directory),
+`MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER` (change the 570 threshold),
+`MLSBENCH_SKIP_GPU_PREFLIGHT=1` (turn the whole thing off).
+
+A separate failure with the same symptom is a **stripped** `libPhysXGpu_64.so`:
+several community IsaacGym images prune the PTX payload, which leaves nothing
+for any driver to JIT. The preflight detects that too and says so explicitly.
+Use the stock Preview 4 binary that
+`vendor/data_scripts/humanoid-gym/prepare_isaacgym.py` downloads.
+
 ## Baseline
 
 The default baseline uses the official PPO implementation from humanoid-gym with:

--- a/tasks/robo-humanoid-sim2real-algo/README.md
+++ b/tasks/robo-humanoid-sim2real-algo/README.md
@@ -29,13 +29,14 @@ The task uses a sim2sim evaluation protocol:
 
 ## Runtime requirement: NVIDIA driver >= 570 on Hopper and newer
 
-IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
-`sm_86`, plus a `compute_86` PTX payload. On a Hopper GPU (`sm_90`) there is no
+IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest cubin is `sm_80`,
+plus a PTX payload targeting `sm_86`. On a Hopper GPU (`sm_90`) there is no
 matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
 created. That JIT runs in the **user-space** driver, and 5xx user-space branches
 older than 570 are known to segfault in it: the run dies with a bare
 `Segmentation fault` inside `create_sim`, no python traceback, and scores 0
-([issue #47](https://github.com/Imbernoulli/MLS-Bench/issues/47)).
+([issue #59](https://github.com/Imbernoulli/MLS-Bench/issues/59), whose gdb
+backtrace lands inside `libnvidia-ptxjitcompiler` on driver 535.161.08).
 
 Only the *user-space* driver has to move — the host's kernel driver can stay on
 535/550. `scripts/gpu_env_preflight.sh`, sourced by every script in this task,
@@ -59,7 +60,8 @@ Overrides: `MLSBENCH_CUDA_COMPAT_DIR` (use your own compat directory),
 
 A separate failure with the same symptom is a **stripped** `libPhysXGpu_64.so`:
 several community IsaacGym images prune the PTX payload, which leaves nothing
-for any driver to JIT. The preflight detects that too and says so explicitly.
+for any driver to JIT ([issue #47](https://github.com/Imbernoulli/MLS-Bench/issues/47)).
+The preflight detects that too and says so explicitly.
 Use the stock Preview 4 binary that
 `vendor/data_scripts/humanoid-gym/prepare_isaacgym.py` downloads.
 

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_diverse.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_diverse.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on diverse mixed commands (forward/backward, lateral, turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for diverse commands

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_diverse.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_diverse.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_forward.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_forward.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_forward.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_forward.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on forward-only commands (minimal lateral/turning)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for forward-only commands

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_highspeed.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_highspeed.sh
@@ -3,7 +3,7 @@
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_highspeed.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_highspeed.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Evaluate on high-speed commands (stress test)
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Set command ranges for high-speed commands

--- a/tasks/robo-humanoid-sim2real-algo/scripts/eval_sim2sim_diverse.py
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/eval_sim2sim_diverse.py
@@ -4,6 +4,25 @@
 import os
 import sys
 
+# --- Thread-oversubscription guard (MUST run before numpy/scipy/torch/mujoco import) ---
+# This eval is CPU-bound (MuJoCo sim loop + small torch policy forward). Each numerical
+# backend (OpenMP, MKL, OpenBLAS, numexpr, torch) otherwise spins up ~ncores threads.
+# When several evals share a node — or even a single eval on a many-core box — these
+# pools oversubscribe the CPU, thrash caches, and slow the wall clock far beyond linear,
+# which is what caused the concurrent evals to time out. Cap thread pools to a small
+# number here. Every cap is idempotent and env-overridable: if the caller already set a
+# value (e.g. via the scheduler) we leave it untouched. BLAS env vars are honored only
+# at import time, so they MUST be set before importing numpy/torch below.
+_DEFAULT_EVAL_THREADS = os.getenv("MLSB_EVAL_THREADS", "8")
+for _var in (
+    "OMP_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+):
+    os.environ.setdefault(_var, _DEFAULT_EVAL_THREADS)
+
 # IMPORTANT: isaacgym MUST be imported before torch (Isaac Gym's gymdeps enforces this).
 # So we do the humanoid.envs import (which transitively imports isaacgym) up front,
 # before any module that pulls in torch.
@@ -19,6 +38,14 @@ import numpy as np
 import mujoco
 from scipy.spatial.transform import Rotation as R
 import torch
+
+# Cap torch's intra-op CPU thread pool to match the BLAS caps set above. torch reads
+# OMP_NUM_THREADS at init, but we set it explicitly so the cap holds regardless of how
+# torch was built or whether the env var propagated. Honors an explicit override.
+try:
+    torch.set_num_threads(int(os.environ.get("OMP_NUM_THREADS", _DEFAULT_EVAL_THREADS)))
+except Exception:
+    pass
 
 
 def quaternion_to_euler_array(quat):

--- a/tasks/robo-humanoid-sim2real-algo/scripts/gpu_env_preflight.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/gpu_env_preflight.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# GPU environment preflight for the IsaacGym legs of this task.
+#
+# Why this exists
+# ---------------
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
+# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
+# created. That JIT lives in the *user-space* driver (libcuda +
+# libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
+# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
+# reported, and what a second site independently confirmed. The kernel driver
+# does not have to be touched: a >= 570 user-space CUDA forward-compatibility
+# stack inside the container is enough, and a host on 535/550 keeps its driver.
+#
+# So before the run we:
+#   1. print one greppable line describing GPU / driver / PhysX device code,
+#   2. transparently activate a bundled >= 570 forward-compat stack when the
+#      user-space driver is too old for the GPU it is driving, and
+#   3. when we cannot fix it, say exactly what to do — instead of letting the run
+#      die later in a bare `Segmentation fault` inside create_sim.
+#
+# This file is *sourced*, not executed, so the LD_LIBRARY_PATH it exports reaches
+# the python child. Everything here is best-effort: it must never abort the run
+# (callers use `set -e`), and a healthy node pays one short probe.
+#
+# Knobs:
+#   MLSBENCH_SKIP_GPU_PREFLIGHT=1            skip entirely
+#   MLSBENCH_CUDA_COMPAT_DIR=<dir>           forward-compat dir to try first
+#   MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER=<maj>  override the 570 threshold
+
+_mls_pf_min_driver="${MLSBENCH_GPU_PREFLIGHT_MIN_DRIVER:-570}"
+_mls_pf_physx_so="${ISAACGYM_PHYSX_SO:-/opt/isaacgym/python/isaacgym/_bindings/linux-x86_64/libPhysXGpu_64.so}"
+
+_mls_pf_python() {
+    command -v python3 2>/dev/null || command -v python 2>/dev/null
+}
+
+# Ask the driver itself, via ctypes, two things at once:
+#   - the realpath of the libcuda.so.1 this process actually loads
+#   - the compute capability of the first visible device
+# Prints "<libcuda-realpath>|<compute-cap>"; either field may be empty. A
+# non-empty compute cap also proves cuInit() succeeded, so this doubles as the
+# "is this driver stack usable" check after we swap LD_LIBRARY_PATH.
+_mls_pf_probe() {
+    local py="$1"
+    [ -n "$py" ] || return 0
+    "$py" - <<'PY' 2>/dev/null
+import ctypes, os
+
+path = ""
+cc = ""
+try:
+    lib = ctypes.CDLL("libcuda.so.1")
+except OSError:
+    lib = None
+if lib is not None:
+    try:
+        for line in open("/proc/self/maps"):
+            candidate = line.rstrip("\n").rsplit(" ", 1)[-1]
+            if "/libcuda.so." in candidate:
+                path = os.path.realpath(candidate)
+                break
+    except OSError:
+        pass
+    try:
+        if lib.cuInit(0) == 0:
+            dev = ctypes.c_int()
+            if lib.cuDeviceGet(ctypes.byref(dev), 0) == 0:
+                major, minor = ctypes.c_int(), ctypes.c_int()
+                # CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_{MAJOR,MINOR}
+                rc_major = lib.cuDeviceGetAttribute(ctypes.byref(major), 75, dev)
+                rc_minor = lib.cuDeviceGetAttribute(ctypes.byref(minor), 76, dev)
+                if rc_major == 0 and rc_minor == 0:
+                    cc = "%d.%d" % (major.value, minor.value)
+    except Exception:
+        pass
+print("%s|%s" % (path, cc))
+PY
+}
+
+# ".../libcuda.so.570.211.01" -> "570.211.01"; anything unversioned -> ""
+_mls_pf_driver_version() {
+    local base="${1##*/}"
+    case "$base" in
+        libcuda.so.[0-9]*.[0-9]*) echo "${base#libcuda.so.}" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Which device code does this PhysX binary actually carry? On Hopper the answer
+# is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
+# which is the second failure mode seen in #47 (community IsaacGym images ship a
+# stripped libPhysXGpu with its PTX payload pruned out).
+_mls_pf_physx_inventory() {
+    local cc="$1" so="$_mls_pf_physx_so" sass ptx want
+    [ -f "$so" ] || return 0
+    command -v cuobjdump >/dev/null 2>&1 || return 0
+    sass="$(timeout 60 cuobjdump --list-elf "$so" 2>/dev/null | grep -o 'sm_[0-9]\+' | sort -u | paste -sd, -)"
+    ptx="$(timeout 60 cuobjdump --list-ptx "$so" 2>/dev/null | grep -c '\.ptx')"
+    echo "GPU_ENV_PREFLIGHT physx sass=${sass:-none} ptx_payloads=${ptx:-0} so=$so"
+    want="sm_${cc%%.*}${cc#*.}"
+    if [ "${ptx:-0}" -eq 0 ] && ! printf '%s' ",${sass}," | grep -q ",${want},"; then
+        cat >&2 <<EOF
+GPU_ENV_PREFLIGHT ERROR: $so carries neither a ${want} cubin nor any PTX, so it
+cannot run on this GPU by any driver path. This is a pruned/stripped IsaacGym
+copy, not a driver problem — restore the stock Preview 4 binary (the one
+vendor/data_scripts/humanoid-gym/prepare_isaacgym.py downloads) and re-run.
+EOF
+    fi
+}
+
+# Prepend the first usable >= min_driver forward-compat directory to
+# LD_LIBRARY_PATH, verifying by re-probing that the new libcuda is the one that
+# actually loads *and* that it initialises (forward compat is a data-center-GPU
+# feature; on other hardware it loads but cuInit fails, so we must roll back).
+_mls_pf_activate_compat() {
+    local py="$1" from="$2" dir saved cand_ver cand_major probe now
+    saved="${LD_LIBRARY_PATH:-}"
+    for dir in "${MLSBENCH_CUDA_COMPAT_DIR:-}" \
+               /opt/mlsbench/cuda-compat \
+               /usr/local/cuda-12.9/compat \
+               /usr/local/cuda-12.8/compat; do
+        [ -n "$dir" ] || continue
+        [ -e "$dir/libcuda.so.1" ] || continue
+        cand_ver="$(_mls_pf_driver_version "$(readlink -f "$dir/libcuda.so.1")")"
+        cand_major="${cand_ver%%.*}"
+        case "$cand_major" in ''|*[!0-9]*) continue ;; esac
+        [ "$cand_major" -ge "$_mls_pf_min_driver" ] || continue
+
+        export LD_LIBRARY_PATH="$dir${saved:+:$saved}"
+        probe="$(_mls_pf_probe "$py")"
+        now="$(_mls_pf_driver_version "${probe%%|*}")"
+        if [ "$now" = "$cand_ver" ] && [ -n "${probe#*|}" ]; then
+            echo "GPU_ENV_PREFLIGHT remediation=cuda-compat dir=$dir user_driver=${from:-unknown}->$now"
+            return 0
+        fi
+        echo "GPU_ENV_PREFLIGHT compat candidate $dir rejected (loaded='${now:-none}', cuInit=${probe#*|})" >&2
+        if [ -n "$saved" ]; then export LD_LIBRARY_PATH="$saved"; else unset LD_LIBRARY_PATH; fi
+    done
+    return 1
+}
+
+_mls_pf_report_unfixable() {
+    local cc="$1" udrv="$2" sm="sm_${1%%.*}${1#*.}"
+    cat >&2 <<EOF
+========================================================================
+GPU_ENV_PREFLIGHT WARNING: this container drives a ${sm} GPU with a
+user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
+
+IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
+to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
+older than ${_mls_pf_min_driver} are known to segfault inside that JIT
+(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+python traceback, and the run then scores 0.
+
+Any one of these fixes it:
+  * run on a host whose NVIDIA driver is >= ${_mls_pf_min_driver}; or
+  * keep the host driver where it is and upgrade only the container's
+    user-space driver, by mounting NVIDIA's cuda-compat package (>= 570,
+    e.g. cuda-compat-12-8) at /opt/mlsbench/cuda-compat:
+        docker run -v /path/to/compat:/opt/mlsbench/cuda-compat ...
+    or by pointing MLSBENCH_CUDA_COMPAT_DIR at wherever you unpacked it.
+    This preflight then activates it automatically; or
+  * re-pull the MLS-Bench humanoid-gym image, which bundles that directory,
+    so no mount is needed.
+
+Continuing anyway — the run may still work, or may segfault in create_sim.
+========================================================================
+EOF
+}
+
+_mls_gpu_env_preflight() {
+    [ "${MLSBENCH_SKIP_GPU_PREFLIGHT:-0}" = "1" ] && return 0
+
+    local py probe libcuda cc cc_major kdrv udrv udrv_major
+    py="$(_mls_pf_python)"
+    probe="$(_mls_pf_probe "$py")"
+    libcuda="${probe%%|*}"
+    cc="${probe#*|}"
+    kdrv="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    udrv="$(_mls_pf_driver_version "$libcuda")"
+    cc_major="${cc%%.*}"
+    udrv_major="${udrv%%.*}"
+
+    echo "GPU_ENV_PREFLIGHT compute_cap=${cc:-unknown} kernel_driver=${kdrv:-unknown} user_driver=${udrv:-unknown} libcuda=${libcuda:-not-loaded}"
+
+    # Everything below only matters on Hopper and newer, where PhysX has no
+    # native cubin and the PTX JIT is on the critical path.
+    case "$cc_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$cc_major" -ge 9 ] || return 0
+
+    _mls_pf_physx_inventory "$cc"
+
+    case "$udrv_major" in ''|*[!0-9]*) return 0 ;; esac
+    [ "$udrv_major" -ge "$_mls_pf_min_driver" ] && return 0
+
+    _mls_pf_activate_compat "$py" "$udrv" || _mls_pf_report_unfixable "$cc" "$udrv"
+}
+
+_mls_gpu_env_preflight || true

--- a/tasks/robo-humanoid-sim2real-algo/scripts/gpu_env_preflight.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/gpu_env_preflight.sh
@@ -3,13 +3,14 @@
 #
 # Why this exists
 # ---------------
-# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest native SASS is
-# sm_86, plus a compute_86 PTX payload. On a Hopper GPU (sm_90) there is no
+# IsaacGym Preview 4 ships a `libPhysXGpu_64.so` whose newest cubin is sm_80,
+# plus a PTX payload targeting sm_86. On a Hopper GPU (sm_90) there is no
 # matching cubin, so the CUDA driver has to JIT-compile that PTX when the sim is
 # created. That JIT lives in the *user-space* driver (libcuda +
 # libnvidia-ptxjitcompiler), and on 5xx user-space branches older than 570 it can
-# segfault instead of emitting sm_90 code — which is what MLS-Bench issue #47
-# reported, and what a second site independently confirmed. The kernel driver
+# segfault instead of emitting sm_90 code — MLS-Bench issue #59 has the gdb
+# backtrace landing inside libnvidia-ptxjitcompiler on driver 535.161.08, and a
+# second site independently confirmed the same. The kernel driver
 # does not have to be touched: a >= 570 user-space CUDA forward-compatibility
 # stack inside the container is enough, and a host on 535/550 keeps its driver.
 #
@@ -90,8 +91,8 @@ _mls_pf_driver_version() {
 
 # Which device code does this PhysX binary actually carry? On Hopper the answer
 # is the whole story: no sm_90 cubin and no PTX means nothing can rescue the run,
-# which is the second failure mode seen in #47 (community IsaacGym images ship a
-# stripped libPhysXGpu with its PTX payload pruned out).
+# which is the other failure mode, diagnosed in #47: community IsaacGym images
+# ship a stripped libPhysXGpu with its PTX payload pruned out.
 _mls_pf_physx_inventory() {
     local cc="$1" so="$_mls_pf_physx_so" sass ptx want
     [ -f "$so" ] || return 0
@@ -151,7 +152,7 @@ user-space CUDA driver of ${udrv:-unknown}, older than ${_mls_pf_min_driver}.x.
 IsaacGym Preview 4's libPhysXGpu_64.so carries no ${sm} cubin, so PhysX has
 to JIT-compile its compute_86 PTX at create_sim. User-space driver branches
 older than ${_mls_pf_min_driver} are known to segfault inside that JIT
-(MLS-Bench issue #47): it surfaces as a bare "Segmentation fault" with no
+(MLS-Bench issue #59): it surfaces as a bare "Segmentation fault" with no
 python traceback, and the run then scores 0.
 
 Any one of these fixes it:

--- a/tasks/robo-humanoid-sim2real-algo/scripts/train.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/train.sh
@@ -2,6 +2,12 @@
 # Train humanoid locomotion policy with custom algorithm and export JIT policy
 set -e
 
+# Diagnose — and where possible repair — the CUDA user-space driver before
+# IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# shellcheck source=gpu_env_preflight.sh
+source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
+
 cd /workspace
 
 # Use SEED (injected by MLS-Bench framework) for reproducibility

--- a/tasks/robo-humanoid-sim2real-algo/scripts/train.sh
+++ b/tasks/robo-humanoid-sim2real-algo/scripts/train.sh
@@ -4,7 +4,7 @@ set -e
 
 # Diagnose — and where possible repair — the CUDA user-space driver before
 # IsaacGym touches the GPU. On Hopper, PhysX has to JIT its compute_86 PTX to
-# sm_90, and pre-570 user-space drivers segfault doing it (issue #47).
+# sm_90, and pre-570 user-space drivers segfault doing it (issue #59).
 # shellcheck source=gpu_env_preflight.sh
 source "$(dirname "${BASH_SOURCE[0]}")/gpu_env_preflight.sh"
 

--- a/vendor/pkg_configs/humanoid-gym/config.json
+++ b/vendor/pkg_configs/humanoid-gym/config.json
@@ -2,6 +2,7 @@
   "base_image": "nvcr.io/nvidia/pytorch:22.04-py3",
   "install_cmds": [
     "apt-get -o APT::Sandbox::User=root update -q && DEBIAN_FRONTEND=noninteractive apt-get -o APT::Sandbox::User=root install -y git wget unzip libgl1-mesa-glx libglib2.0-0 libsm6 libxext6 libxrender-dev libx11-6 libxcursor1 libxinerama1 libxrandr2 libxi6 libxxf86vm1 libvulkan1 vulkan-tools mesa-vulkan-drivers gdb strace && apt-get clean && rm -rf /var/lib/apt/lists/*",
+    "wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-compat-12-8_570.211.01-0ubuntu1_amd64.deb -O /tmp/cuda-compat.deb && dpkg -x /tmp/cuda-compat.deb /tmp/cuda-compat && mkdir -p /opt/mlsbench/cuda-compat && cp -a /tmp/cuda-compat/usr/local/cuda-12.8/compat/. /opt/mlsbench/cuda-compat/ && rm -rf /tmp/cuda-compat.deb /tmp/cuda-compat && test -e /opt/mlsbench/cuda-compat/libcuda.so.1",
     "rm -f /usr/share/vulkan/icd.d/intel_icd.x86_64.json /usr/share/vulkan/icd.d/lvp_icd.x86_64.json /usr/share/vulkan/icd.d/radeon_icd.x86_64.json && mkdir -p /usr/share/vulkan/icd.d && printf '%s\\n' '{' '    \"file_format_version\" : \"1.0.0\",' '    \"ICD\": {' '        \"library_path\": \"libGLX_nvidia.so.0\",' '        \"api_version\" : \"1.2.155\"' '    }' '}' > /usr/share/vulkan/icd.d/nvidia_icd.json",
     "pip install numpy==1.23.5",
     "cd /opt/isaacgym/python && pip install -e .",


### PR DESCRIPTION
Closes #59; also covers the environment-side half of #47.

#59 is an unusually complete report and it pins the cause exactly: driver
`535.161.08`, stock `libPhysXGpu_64.so` (sha256 `2a475f57…`), a minimal
`create_sim()` reproducer, and a gdb backtrace whose frames land in
`libnvidia-ptxjitcompiler.so.1 → __cuda_CallJitEntryPoint → libcuda.so →
physx::KernelWrangler::KernelWrangler`. The PTX JIT itself segfaults. It asks
"do you have a recommended driver/runtime combination for H100" — the answer is
its own option 1, and this PR ships it rather than leaving it as advice.

## What was actually wrong

IsaacGym Preview 4's `libPhysXGpu_64.so` carries cubins for
sm_50/60/70/75/80 and a PTX payload targeting `sm_86`. On Hopper there is no
matching cubin, so the CUDA driver has to JIT that PTX to `sm_90` when the sim
is created. **That JIT runs
in the user-space driver** (`libcuda` + `libnvidia-ptxjitcompiler`), and 5xx
user-space branches older than 570 can segfault inside it. The failure surfaces
as a bare `Segmentation fault` in `create_sim` with no python traceback, and the
run scores 0.

We never reproduced it because our node runs driver `570.195.03`. A second site
hit it on 535/550 and fixed it by giving the *container* a 570 user-space driver
while leaving the *host* kernel driver untouched — which is exactly what CUDA
forward-compatibility packages are for. That report is what this PR turns into
shipped behaviour.

## What this changes

**`scripts/gpu_env_preflight.sh`** (new, sourced by all four task scripts):

1. Asks the driver through `ctypes` which `libcuda` actually loaded and what the
   device's compute capability is, and logs one greppable line:
   ```
   GPU_ENV_PREFLIGHT compute_cap=9.0 kernel_driver=570.195.03 user_driver=570.195.03 libcuda=/usr/lib/x86_64-linux-gnu/libcuda.so.570.195.03
   ```
   Reading it from the driver rather than from `nvidia-smi` matters: `nvidia-smi`
   reports the *kernel* driver, and the whole point here is that the two can
   legitimately differ.
2. On `sm_90`+ with a pre-570 user-space driver, prepends a `>= 570` forward-compat
   directory to `LD_LIBRARY_PATH`, then re-probes to confirm the new `libcuda` is
   the one that loads **and** that `cuInit` succeeds — rolling back if not.
   Forward compat is a data-center-GPU feature, so it must never be forced.
3. Inventories `libPhysXGpu_64.so` with `cuobjdump`. This catches the other half
   of #47: several community IsaacGym images prune the PTX payload, which leaves
   nothing for any driver to JIT. Same symptom, unrelated cause, and no driver
   change fixes it — so the preflight says so explicitly instead of letting it
   look like the driver bug.
4. When it cannot repair the stack, prints the three ways to fix it.

**Image**: `humanoid-gym` now bakes NVIDIA's `cuda-compat-12-8` (570.211.01) at
`/opt/mlsbench/cuda-compat`, so step 2 needs no bind mount once the image is
rebuilt. Operators on an older image can mount their own there, or point
`MLSBENCH_CUDA_COMPAT_DIR` at it.

Nothing here can abort a run. The callers use `set -e`, so the entry point is a
function invoked as `|| true`, which suspends `errexit` for its whole body.

## Verification

On an H100 node (kernel driver 570.195.03):

| check | result |
|---|---|
| healthy node | one `GPU_ENV_PREFLIGHT` line, no action, `LD_LIBRARY_PATH` untouched |
| **real forward-compat activation** — threshold forced to 575 | loads `575.57.08` user-space `libcuda` and `cuInit`s successfully **against the 570.195.03 kernel driver**; the child process confirms it resolves to the compat copy |
| candidate that cannot load | rejected, `LD_LIBRARY_PATH` rolled back, warning printed |
| preexisting `LD_LIBRARY_PATH` | prepended to, not clobbered |
| Harbor invocation (`bash <abs-path>`, unrelated cwd) | sibling script resolves; scripts continue normally |
| new install command, clean container | 193 MB extracted, symlinks intact |

The preflight would have printed, on #59's node:
```
GPU_ENV_PREFLIGHT compute_cap=9.0 kernel_driver=535.161.08 user_driver=535.161.08 libcuda=/usr/lib/x86_64-linux-gnu/libcuda.so.535.161.08
GPU_ENV_PREFLIGHT physx sass=sm_50,sm_60,sm_70,sm_75,sm_80 ptx_payloads=1 so=/opt/isaacgym/...
```
— i.e. it names the cause in the first two lines of the log, and with the
rebuilt image repairs it instead of reporting it.


The middle row is the one that matters: it exercises the exact user-space /
kernel-driver split the fix depends on, on real hardware.

## Also in this PR

- **Thread-oversubscription guard for the sim2sim evals** — it has been in the
  development tree since the concurrent evals started timing out, but was never
  propagated here, so public and Harbor still shipped the unguarded script.
  Harbor makes it worse than native: the mini-scheduler launches every
  `(test_cmd, seed)` in a group at once, so all three sim2sim evals run
  concurrently and each lets OpenMP/MKL/OpenBLAS/numexpr/torch spin up ~ncores
  threads.
- **`dataset.toml`** regenerated — exactly one digest moves.
- **Two stale `test_adapter` expectations** — `_verifier_timeout_sec` charges
  each serialized wave `WAVE_GRACE_SEC`, but the tests still encoded the pre-#68
  budget and were short by 300s per wave. They now import the constant instead
  of restating it. (The other four `test_adapter` failures are pre-existing and
  unrelated: they resolve real package sources under `vendor/<pkg>`, which this
  repo does not ship, and fail identically on a clean `main`.)

## Not done here

The `humanoid-gym` / `harbor-humanoid-gym` images still need a rebuild + push
for `/opt/mlsbench/cuda-compat` to exist in the published images. Until then the
preflight still diagnoses correctly and accepts a mounted compat directory — it
just cannot self-repair from the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
