### PR TITLE
Note the Kimi K3 and Qwen3.8-Max adoptions in News

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The benchmark contains **140 tasks across 12 ML research domains**. Each task fi
 
 ## News
 
+- **2026.8** — **MLS-Bench adopted by Alibaba (Qwen)** [Qwen3.8-Max](https://qwen.ai/blog?id=qwen3.8)!
+- **2026.7** — **MLS-Bench adopted by Moonshot (Kimi)** [Kimi K3](https://www.kimi.com/blog/kimi-k3)!
 - **2026.6** — **MLS-Bench adopted by Moonshot (Kimi)** [Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code)!
 - **2026.6** — **More efficient on larger GPUs**: a new `compute_scale` option lets the LLM pretraining and reinforcement-learning tasks — and, optionally, the other tasks — run more efficiently on H200-class GPUs without changing results. See issue [#4](https://github.com/Imbernoulli/MLS-Bench/issues/4) and PR [#9](https://github.com/Imbernoulli/MLS-Bench/pull/9) for the design.
 - **2026.5** — **Harbor support**: official Harbor-compatible runtime and pre-rendered task images on Docker Hub under `bohanlyu2022/mlsbench-harbor-*`. See [`harbor/README.md`](harbor/README.md).


### PR DESCRIPTION
Two more labs report MLS-Bench-Lite in a flagship launch post, so add a News line for each.

- **Kimi K3** ([blog](https://www.kimi.com/blog/kimi-k3)) — reports "MLS Bench Lite" in its full benchmark table, evaluated with the Kimi Code harness at max reasoning effort. K3 scores 48.3.
- **Qwen3.8-Max** ([blog](https://qwen.ai/blog?id=qwen3.8)) — reports MLS-Bench-Lite under the Claude Code harness with a 5-hour timeout and `max_tokens=131,072`. Qwen3.8-Max scores 41.0 and Qwen3.7-Max 31.7; the post takes the other models' numbers from our official leaderboard.

Both scores are also now on the website leaderboard (`mls-bench-website@499a2ab`).

The 5-hour exploration-budget documentation moved to #77 — it was pushed to this branch just after this PR merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)