### PR TITLE
adapter: render A-pattern tasks (forward-port from the frozen harbor-adapter branch)

### DIFF
--- a/harbor_adapter/src/mls_bench/adapter.py
+++ b/harbor_adapter/src/mls_bench/adapter.py
@@ -203,7 +203,38 @@ class MlsBenchAdapter:
 
 _TIME_RE = re.compile(r"^(\d+):(\d+):(\d+)$")
 
-_ALLOWED_OP_IMPORT_ROOTS = {"custom_template", "importlib", "json", "math", "pathlib", "sys"}
+# The A-pattern (public PR #54, and every task rebuilt on it since) keeps the
+# generator, the reference answer and the metric in a host-only
+# ``holdout/<task>/dgp.py`` and has ``mid_edit.py`` import it to stage ONLY the
+# observable inputs into the workspace. That import chain needs numpy to build
+# the arrays, base64+io to encode them, os/sys.path to reach the holdout module,
+# and ``dgp`` itself. Without these roots the adapter cannot render any
+# leak-closed task -- it dies at "import of 'base64' is not allowed" -- and that
+# is 35 tasks today.
+#
+# ``__future__`` is separate and duller: ``from __future__ import annotations``
+# opens a large share of this repo's Python files, and blocking it stopped
+# gfx-mesh-pooling-criterion rendering for a reason unrelated to what the module
+# goes on to do.
+
+# Module names that are task-LOCAL: each task ships its own file under these
+# names, so neither may survive between two op files in one render run.
+_TASK_LOCAL_OP_MODULES = ("custom_template", "dgp")
+
+_ALLOWED_OP_IMPORT_ROOTS = {
+    "__future__",
+    "base64",
+    "custom_template",
+    "dgp",
+    "importlib",
+    "io",
+    "json",
+    "math",
+    "numpy",
+    "os",
+    "pathlib",
+    "sys",
+}
 
 
 def _warn(message: str) -> None:
@@ -437,16 +468,25 @@ def _load_ops_file(ops_py: Path) -> list[dict]:
     }
     old_sys_path = list(sys.path)
     sentinel = object()
-    saved_custom_template = sys.modules.pop("custom_template", sentinel)
+    # Every task has its own module under these names -- ``custom_template`` in
+    # its edits/ dir, and ``dgp`` in the host-only holdout/<task>/ dir that an
+    # A-pattern mid_edit puts on sys.path. Restoring sys.path is not enough,
+    # because the import is cached: render task A then task B in one run and
+    # B's ``import dgp`` returns A's module, so B stages A's DATA. That surfaced
+    # once as "too many values to unpack" only because the two tasks' gen_input
+    # arities differed -- two tasks with matching signatures would render,
+    # build, run and score against the wrong instance in complete silence.
+    saved = {name: sys.modules.pop(name, sentinel) for name in _TASK_LOCAL_OP_MODULES}
     try:
         exec(compile(ops_py.read_text(), str(ops_py), "exec"), ns, ns)
         return _validate_ops(ns.get("OPS"), ops_py)
     finally:
         sys.path[:] = old_sys_path
-        if saved_custom_template is sentinel:
-            sys.modules.pop("custom_template", None)
-        else:
-            sys.modules["custom_template"] = saved_custom_template
+        for name, prev in saved.items():
+            if prev is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
 
 
 def _assert_python_syntax(
@@ -1609,6 +1649,29 @@ def _stage_verifier_assets(
     )
     if (task_dir / "budget_check.py").exists():
         shutil.copy2(task_dir / "budget_check.py", meta / "budget_check.py")
+    # A-pattern tasks keep the generator, the reference answer and the metric in
+    # a host-only ``holdout/<task>/dgp.py``. The parser imports it at scoring
+    # time and looks for it beside itself in the Harbor layout, so it has to be
+    # staged here -- NOT into the workspace, which is the whole point of the
+    # pattern. Without this the bundle renders, builds and runs, and then scores
+    # nothing because the parser cannot import dgp: reward 0, no error anyone
+    # sees.
+    #
+    # The whole holdout dir is staged, not just dgp.py: a dgp may need
+    # verifier-only assets to rebuild the reference, and tests/ is mounted at
+    # /tests ONLY at verification time, so this is the one place an asset can
+    # live that the scorer can read and the agent cannot. gfx-inr-* keeps its
+    # Kodak plates here for exactly that reason -- baking them into /data would
+    # let the agent's own code correlate its staged pixels against a plate and
+    # recover the crop offset that task hides.
+    holdout_dir = task_dir.parent.parent / "holdout" / ctx.task_id
+    if (holdout_dir / "dgp.py").exists():
+        for src in sorted(holdout_dir.rglob("*")):
+            if src.is_dir() or "__pycache__" in src.parts or src.suffix in {".pyc", ".pyo"}:
+                continue
+            dst = meta / src.relative_to(holdout_dir)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
     (meta / "task_id").write_text(ctx.task_id + "\n")
     (meta / "package").write_text(ctx.package + "\n")
     (meta / "workdir").write_text(ctx.pkg_config.get("workdir", "/workspace") + "\n")

--- a/harbor_adapter/tests/test_adapter.py
+++ b/harbor_adapter/tests/test_adapter.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[2]
 ADAPTER_SRC = ROOT / "harbor_adapter" / "src"
@@ -223,6 +225,74 @@ def test_ops_loader_isolates_custom_template_imports(tmp_path: Path):
 
     assert _load_ops_file(first / "mid_edit.py")[0]["content"] == "FIRST"
     assert _load_ops_file(second / "mid_edit.py")[0]["content"] == "SECOND"
+
+
+def test_ops_loader_isolates_dgp_imports(tmp_path: Path):
+    """Same hazard as custom_template, but for the A-pattern's held-out dgp.
+
+    Each A-pattern task ships its own ``holdout/<task>/dgp.py`` and its
+    mid_edit puts that directory on sys.path. Restoring sys.path is not enough
+    because the import is cached, so rendering task A then task B in one run
+    made B's ``import dgp`` return A's module -- and B staged A's DATA into its
+    own bundle. It renders, builds, runs and scores against the wrong instance
+    without printing anything.
+    """
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    for directory, value in ((first, "FIRST"), (second, "SECOND")):
+        (directory / "dgp.py").write_text(
+            f'def opaque_label(env):\n    return "{value}"\n'
+        )
+        (directory / "mid_edit.py").write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "sys.path.insert(0, str(Path(__file__).parent))\n"
+            "import dgp\n"
+            'OPS = [{"op": "create", "file": "pkg/f.py", "content": dgp.opaque_label("e")}]\n'
+        )
+
+    assert _load_ops_file(first / "mid_edit.py")[0]["content"] == "FIRST"
+    assert _load_ops_file(second / "mid_edit.py")[0]["content"] == "SECOND"
+
+
+def test_ops_loader_allows_a_pattern_import_roots(tmp_path: Path):
+    """An A-pattern mid_edit needs numpy/base64/io/os to stage its inputs.
+
+    Blocking any one of them makes every leak-closed task unrenderable, which
+    is how the whole family sat broken on this branch: the loader raised
+    "import of 'base64' is not allowed while loading edit ops".
+    """
+    d = tmp_path / "t"
+    d.mkdir()
+    (d / "mid_edit.py").write_text(
+        "from __future__ import annotations\n"
+        "import base64, io, os, sys\n"
+        "import numpy as np\n"
+        "buf = io.BytesIO()\n"
+        "np.save(buf, np.arange(3))\n"
+        "OPS = [{\n"
+        '    "op": "create",\n'
+        '    "file": "pkg/inputs.b64",\n'
+        '    "content": base64.b64encode(buf.getvalue()).decode("ascii"),\n'
+        "}]\n"
+    )
+
+    ops = _load_ops_file(d / "mid_edit.py")
+
+    assert ops[0]["file"] == "pkg/inputs.b64"
+    assert ops[0]["content"]
+
+
+def test_ops_loader_still_blocks_unlisted_imports(tmp_path: Path):
+    """Widening the allowlist must not turn it into "anything goes"."""
+    d = tmp_path / "t"
+    d.mkdir()
+    (d / "mid_edit.py").write_text("import socket\nOPS = []\n")
+
+    with pytest.raises(ImportError):
+        _load_ops_file(d / "mid_edit.py")
 
 
 def test_apply_ops_delete_line_form_and_replace_to_eof():


### PR DESCRIPTION
Three adapter fixes were pushed to `harbor-adapter` and never reached `main`.
That branch is a frozen pre-merge snapshot, so `main` — the branch the adapter
is actually developed and used from — has been unable to render **any**
A-pattern (leak-closed) task since the pattern was introduced. There are **35**
of them in dev's `holdout/`.

Reproduced on unmodified `main`:

```
ImportError: import of 'base64' is not allowed while loading edit ops
```

## What this changes

1. **Widen `_ALLOWED_OP_IMPORT_ROOTS`.** An A-pattern `mid_edit.py` imports the
   host-only `holdout/<task>/dgp.py` and stages only the observable inputs —
   that needs `numpy` to build the arrays, `base64`+`io` to encode them, and
   `os`/`sys.path` to reach the module. `__future__` is separate and duller:
   `from __future__ import annotations` opens a large share of the repo.
2. **Stage the whole `holdout/<task>/` dir into `tests/meta/`.** The parser
   imports `dgp` at scoring time and looks for it beside itself. The whole dir,
   not just `dgp.py`, because a dgp may need verifier-only assets and `tests/`
   is mounted at `/tests` only at verification time.
3. **Purge `dgp` and `custom_template` from `sys.modules` between op files.**
   Both are task-*local* names. Restoring `sys.path` is not enough — the import
   is cached, so rendering task A then B in one run made B's `import dgp` return
   A's module and **B staged A's data**.

Failure modes 2 and 3 are silent: the bundle renders, builds, runs, and either
scores against the wrong instance or scores 0 with nothing printed.

## Verification

- `gfx-geo-normal-estimation` renders (it did not before).
- `dgp.py` is at `tests/meta/dgp.py` and **nowhere** under `environment/`; no
  file in `environment/` mentions the surface family.
- Rendering it together with `gfx-geo-curvature-estimator` in one run gives each
  bundle its own opaque labels and its own staged data.
- 3 regression tests added, all passing.

The 4 pre-existing `test_adapter.py` failures are unrelated and present on
unmodified `main`.

## Separate problem this surfaced (not fixed here)

`holdout/` does not exist in this repo at all, but **12 tasks** in `tasks/` have
a `mid_edit.py` that imports `dgp`. Those tasks cannot be re-rendered from
public, and two of the four pre-existing test failures are exactly that
(`ModuleNotFoundError: No module named 'dgp'`). The rendered bundles are fine —
30 of them already carry `tests/meta/dgp.py`. Publishing `holdout/` would make
the repo self-consistent and would disclose nothing that those 30 bundles do not
already contain, but that is a disclosure call for @Imbernoulli, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)