### PR TITLE
Daytona: make GPU sandboxes ephemeral so organizations that require it accept them

### DIFF
--- a/harbor_adapter/src/mls_bench/harbor_env.py
+++ b/harbor_adapter/src/mls_bench/harbor_env.py
@@ -422,6 +422,15 @@ def _is_gpu_reservation_only_compose(
 class DaytonaEnvironment(_HarborDaytonaEnvironment):
     """Daytona provider with MLS-Bench's GPU-only Compose compatibility."""
 
+    def _bool_kwarg(self, name: str, *, default: bool) -> bool:
+        """Read a boolean ``--ek`` kwarg, accepting the usual spellings."""
+        raw = self._kwargs.get(name)
+        if raw is None:
+            return default
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
     def _int_kwarg(self, name: str) -> int:
         """Return an integer environment kwarg (``--ek name=value``) or 0."""
         value = self._kwargs.get(name)
@@ -493,6 +502,17 @@ class DaytonaEnvironment(_HarborDaytonaEnvironment):
         if gpu_count > 0:
             if self._spot_requested() and hasattr(params, "spot"):
                 params.spot = True
+            # Some Daytona organizations require GPU sandboxes to be ephemeral
+            # and refuse the create outright: `GPU sandboxes must be ephemeral;
+            # set autoDeleteInterval to 0`. Setting it costs nothing where the
+            # policy is absent — Harbor deletes the sandbox itself when the
+            # trial ends, so this only guarantees cleanup if that path is
+            # missed — and it is what makes the create succeed where the policy
+            # is enforced. `--ek ephemeral_gpu=false` opts out.
+            if self._bool_kwarg("ephemeral_gpu", default=True) and hasattr(
+                params, "auto_delete_interval"
+            ):
+                params.auto_delete_interval = 0
             if resources is not None and gpu_type is not None:
                 resources.gpu_type = gpu_type
             # The verifier runs inside the Daytona sandbox (and, for GPU-only


### PR DESCRIPTION
A second Daytona organization refuses any GPU sandbox that is not ephemeral:

```
Failed to create sandbox: GPU sandboxes must be ephemeral; set autoDeleteInterval to 0
```

Every GPU trial there fails at create — before the image is built, before the agent runs — while CPU-only tasks work fine. The failure therefore reads as "this provider is broken for GPU work" rather than as a policy the request has to satisfy.

## The change

`DaytonaEnvironment._create_sandbox` sets `auto_delete_interval = 0` on GPU sandboxes. Default on; `--ek ephemeral_gpu=false` opts out. One file, 20 lines.

Where the policy is absent the setting costs nothing — Harbor deletes the sandbox itself when a trial ends, so this only guarantees cleanup if that path is missed.

That guarantee has already been worth having once. A Harbor environment-build retry created two sandboxes for one trial on the first organization; when the trial finished, Harbor deleted the one it was tracking and left the other `STARTED` with no process inside, holding **2 of the 10 GPU quota** indefinitely because nothing owned it any more. An ephemeral sandbox cannot strand quota that way.

## Verified on the second organization

Stock `run-daytona.yaml` path, same bundles:

| task | reward | notes |
| --- | --- | --- |
| `ml-clustering-algorithm` (CPU) | 0.35451013037469825 | identical to the first organization |
| `ts-exogenous-forecast` (1 GPU) | 0.4933602152328324 | all three evals rc=0 (27 / 49 / 275 s); first organization gives 0.4934 |

A single sandbox there takes **8 GPUs** and sees all eight H100s. Both `H100` and `H200` are selectable through `Resources.gpu_type`, so the Hopper pinning this repo relies on works there too.

One correction worth recording, since it nearly became a wrong conclusion: `gpu_type` is **not** a field on `CreateSandboxFromImageParams`. Passing it there is silently ignored and Daytona places the sandbox on whatever it likes — in my first probe, an RTX PRO 6000 Blackwell, which has no kernels for these images' pinned CUDA wheels. It has to be set on the `Resources` object, which is what `_create_sandbox` already does. A probe that gets this wrong will conclude an organization has no H100s when it does.

Suite: 97 passed, 4 pre-existing failures that need the un-vendored packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)