### PR TITLE
cv-dbm: evaluate the full DIODE split so FID stops depending on the filesystem

### DIFF
--- a/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
+++ b/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
@@ -1,5 +1,5 @@
 timestamp,model,is_final,seed,best_fid_edges2handbags,best_fid_Imagenet,best_fid_DIODE,elapsed_DIODE
-2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,15.002,271.2
-2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,14.306,274.8
+2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,14.204,499.3
+2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,13.506,482.8
 2026-04-19T00:00:00.000000+00:00,baseline:ddbm,true,42,11.139,10.556,15.811,2149.3
-2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.999,270.2
+2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.239,497.5

--- a/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-daytona/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-daytona/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-daytona/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/harbor/tasks-daytona/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-daytona/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
+++ b/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
@@ -1,5 +1,5 @@
 timestamp,model,is_final,seed,best_fid_edges2handbags,best_fid_Imagenet,best_fid_DIODE,elapsed_DIODE
-2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,15.002,271.2
-2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,14.306,274.8
+2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,14.204,499.3
+2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,13.506,482.8
 2026-04-19T00:00:00.000000+00:00,baseline:ddbm,true,42,11.139,10.556,15.811,2149.3
-2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.999,270.2
+2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.239,497.5

--- a/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-docker/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-docker/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-docker/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/harbor/tasks-docker/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-docker/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/eval/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
+++ b/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/meta/leaderboard.csv
@@ -1,5 +1,5 @@
 timestamp,model,is_final,seed,best_fid_edges2handbags,best_fid_Imagenet,best_fid_DIODE,elapsed_DIODE
-2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,15.002,271.2
-2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,14.306,274.8
+2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,14.204,499.3
+2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,13.506,482.8
 2026-04-19T00:00:00.000000+00:00,baseline:ddbm,true,42,11.139,10.556,15.811,2149.3
-2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.999,270.2
+2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.239,497.5

--- a/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-modal/mls-bench__cv-dbm-sampler/tests/meta/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/harbor/tasks-modal/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
+++ b/harbor/tasks-modal/mls-bench__cv-dbm-scheduler/tests/eval/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/harbor/tasks-modal/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
+++ b/harbor/tasks-modal/mls-bench__cv-dbm-scheduler/tests/meta/scripts/run_DIODE.sh
@@ -2,7 +2,35 @@ set -euo pipefail
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3

--- a/tasks/cv-dbm-sampler/leaderboard.csv
+++ b/tasks/cv-dbm-sampler/leaderboard.csv
@@ -1,5 +1,5 @@
 timestamp,model,is_final,seed,best_fid_edges2handbags,best_fid_Imagenet,best_fid_DIODE,elapsed_DIODE
-2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,15.002,271.2
-2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,14.306,274.8
+2026-04-19T00:00:00.000000+00:00,baseline:dbim,true,42,5.180,6.070,14.204,499.3
+2026-04-19T00:00:00.000000+00:00,baseline:dbim_high_order,true,42,4.988,5.528,13.506,482.8
 2026-04-19T00:00:00.000000+00:00,baseline:ddbm,true,42,11.139,10.556,15.811,2149.3
-2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.999,270.2
+2026-04-19T00:00:00.000000+00:00,baseline:ecsi,true,42,4.234,52.60,5.239,497.5

--- a/tasks/cv-dbm-sampler/scripts/run_DIODE.sh
+++ b/tasks/cv-dbm-sampler/scripts/run_DIODE.sh
@@ -10,7 +10,35 @@ source "$(dirname "${BASH_SOURCE[0]}")/_runtime_patch.sh"
 
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=5
@@ -48,7 +76,7 @@ elif [ "$status" -eq 0 ]; then
 fi
 
 # Clean up THIS dataset's sample NPZs once FID has been computed — each agent
-# iteration would otherwise keep a ~2 GB (10k × 256x256x3 uint8) NPZ on Vepfs.
+# iteration would otherwise keep a ~3.2 GB (16502 × 256x256x3 uint8) NPZ on Vepfs.
 # The delete is scoped to the diode model dirs: all three settings share
 # workdir/ and can run concurrently, so an unscoped `find workdir/ -delete`
 # races a concurrent setting that is still reading its own samples and zeroes

--- a/tasks/cv-dbm-scheduler/scripts/run_DIODE.sh
+++ b/tasks/cv-dbm-scheduler/scripts/run_DIODE.sh
@@ -1,6 +1,34 @@
 export eta=0.0
 export ds=diode
-export num_samples=10000
+# Evaluate the FULL DIODE split (16502 images), not a 10000-image prefix.
+#
+# The prefix was irreproducible. `datasets/aligned_dataset.py` builds DIODE's
+# file list with a bare `os.listdir()` and never sorts it (the sibling
+# EdgesDataset does sort, at L92), so "the first 10000" was whatever order the
+# filesystem happened to return. Measured on cv-dbm-sampler's `dbim` baseline --
+# same code, weights, seed and hardware, only the listing order differing:
+#
+#     num_samples   natural (ext4) order   sorted order
+#         10000                 15.0316        30.2292   <- 101% swing
+#         16502                 14.2039        14.2469   <- 0.3%
+#
+# Sorting groups the filenames by scene, so a sorted 10000-prefix truncated the
+# eval from 97 scenes to 61 and shared only 61% of its images with the natural
+# order. The subset also shifted with the rank count, because DistributedSampler
+# interleaves indices across ranks before the early exit.
+#
+# Sampling the whole split removes the dependency: FID is a statistic over a
+# set, and the set is now the entire split whatever order it is listed in. The
+# 0.043 residual above is seed noise rather than order -- sample.py seeds each
+# image as `indexes + seed`, so reordering the list relabels every noise draw;
+# three seeds at natural order span 0.0393 (sd 0.0210), putting the sorted run
+# 1.6 sd out, against 723 sd before.
+#
+# It is also the comparison the reference was built for:
+# assets/stats/diode_ref_256_data.npz holds exactly these 16502 images and
+# upstream's evaluate.sh expects samples_16502x256x256x3. sample.py clamps
+# num_samples to len(dataset), so this stays correct if the split ever grows.
+export num_samples=16502
 export doob_scale=1.0
 export sampler=dbim
 export nfe=3


### PR DESCRIPTION
## The defect

`dbim-codebase/datasets/aligned_dataset.py` builds DIODE's file list with a bare
`os.listdir()` and never sorts it — the sibling `EdgesDataset` **does** sort, at
L92. Both `cv-dbm-sampler` and `cv-dbm-scheduler` then asked for
`num_samples=10000` out of 16502, so *"the first 10000"* was whatever order the
filesystem happened to return.

Replaying the exact selection logic (`DistributedSampler(shuffle=False)` →
`DataLoader(bs=16)` → `all_gather` in rank order → break at `num_samples`), with
no model in the loop:

| `num_samples` | listdir vs sorted | scene coverage | across 3/4/8 ranks |
|---|---|---|---|
| 10000 (before) | **60.8 % overlap** — 39 % of evaluated images differ | 97 → **61** scenes | differs |
| 16502 (after) | **identical set** | 97 either way | differs by **1/16502** (0.006 %) |

Sorting groups DIODE filenames by scene, so a sorted 10000-prefix truncates the
eval to the lowest-numbered scenes.

## End-to-end confirmation — `cv-dbm-sampler` / `dbim`, 4×H100

Same code, weights, seed and hardware; only the listing order differs.

| `num_samples` | natural (ext4) order | **sorted** order | order sensitivity |
|---|---|---|---|
| **10000** (before) | 15.0316 | **30.2292** | **15.198 FID (101 %)** |
| **16502** (after) | 14.2039 | 14.2469 | **0.043 FID (0.3 %)** |

**354× reduction.** The top-left cell reproduces the shipped anchor (15.002), so
the matrix is anchored to the published value rather than to this host.

The 0.043 residual is **not** leftover order dependence. `sample.py:115` seeds
each sample as `indexes + args.seed`, where `indexes` is the image's position in
the file list — so reordering relabels every noise draw while leaving the image
set identical. Three seeds at natural order give 14.2039 / 14.2364 / 14.1971
(sd **0.0210**), putting the sorted run **1.6 σ** from the seed mean — against
**723 σ** before the change.

Cross-check: the same run in the Harbor bundle image gives **14.2039**, identical
at the 3-decimal precision `parser.py:53` stores. Natively-derived anchors are
therefore exactly what `score_task.py` compares bundle runs against.

## Why the full split rather than `sorted()`

Sorting would have **frozen the bad case** — sorted order is what the affected
provider was already doing (30.23 vs 15.03) — and would have required patching
the package inside the 41 GB base image. Sampling everything removes the
dependency instead of picking one arbitrary order, and restores the comparison
the reference was built for: `diode_ref_256_data.npz` holds exactly these 16502
images and upstream's `evaluate.sh` expects `samples_16502x256x256x3`.

Cost is 1.84× measured. The slowest baseline projects to ~27 % of its 4 h `time`,
and the NPZ grows ~2 GB → ~3.2 GB against a 60 GB `storage_mb`, so no `time`,
`[verifier].timeout_sec` or resource change is needed.

## Re-derived anchors — `cv-dbm-sampler` only

Via `mlsbench baseline --label DIODE`, the same path that produced them.

| baseline | best_fid_DIODE | |
|---|---|---|
| dbim | 15.002 → **14.204** | |
| dbim_high_order | 14.306 → **13.506** | |
| ecsi | 5.999 → **5.239** | sets the calibration ref |
| ddbm | 15.811 *(kept)* | see below |

`mlsbench score --check`: 3 terms, 3 settings, **0 warnings**.
`harbor_adapter` suite: 97 passed, 4 failures pre-existing and outside this change.

## tasks/ ↔ harbor/ consistency

| group | files | state |
|---|---|---|
| `run_DIODE.sh` (native ×2, and `tests/eval/` + `tests/meta/` across docker/daytona/modal) | 14 | changed region byte-identical in all 14 (single sha `3881c1bdbfea`) |
| `cv-dbm-sampler` `leaderboard.csv` (native + 3 bundles) | 4 | updated together, all identical |
| `cv-dbm-scheduler` `leaderboard.csv` (native + 3 bundles) | 4 | untouched, all identical |

The `cv-dbm-scheduler` bundle scripts carry hand-edited provider fixes absent
from the native script, so they were patched surgically rather than re-rendered.
No re-render is needed: `oracle_cmd_overrides.token` derives from task id /
baseline / overrides, not script bytes, and `pristine_manifest.json` covers
package files only. No rendered `instruction.md` quotes these anchors.

## Deliberately NOT fixed here — two pre-existing defects this surfaced

**1. `cv-dbm-sampler`'s `ddbm` baseline is unreproducible.** It dies in the first
batch with `NFE_BUDGET_EXCEEDED` — it is the Heun sampler, needing ~9 denoiser
calls against the `steps+1 = 5` budget enforced by pre_edit OP 6d — at *any*
sample count. Its row predates that guard. Left untouched: it is never best on
any metric, so it only sets the DIODE floor, and leaving it stale costs ≤0.011 of
score anywhere an agent realistically lands. Note its kept `elapsed_DIODE`
(2149.3 s) is a 10000-sample figure; full-split projects to ~3950 s.

**2. `cv-dbm-scheduler`'s anchors were not measured at its current `nfe=3`.**
Provable without measurement — the cosine ramp `(1−cos πx)/2` is the identity at
x ∈ {0, ½, 1}, so at `n=2` the cosine schedule **is** the uniform schedule:

```
n=2 (nfe=3): uniform [1.0, 0.50005, 0.0001]  cosine [1.0, 0.50005, 0.0001]  max diff 1.7e-08
n=4 (nfe=5): uniform [1.0, 0.750025, ...]    cosine [1.0, 0.853568, ...]    max diff 1.0e-01
```

At `nfe=3` those two baselines must score identically — and measured, they do
(25.838637 vs 25.838648). The recorded leaderboard lists cosine **11.966** and
uniform **15.002**, and uniform's row is byte-identical to `cv-dbm-sampler`'s
`dbim` row on all three metrics, which is what you get at `nfe=5`.

This change is not responsible: `karras` measures **37.791** at the old setting
and **36.854** at the new one, against a recorded **8.772**.

So at `nfe=3` that task has only **three distinct baselines**, not four, and all
four anchors are stale. `cv-dbm-scheduler/leaderboard.csv` is therefore left
untouched — writing one freshly-measured column into a wholly stale file would
launder it. The script fix still applies there, because the ordering defect is
real in that task too. Worth a separate issue.

## Does this bug actually fire? Measured: no.

An earlier draft of this PR claimed the defect had corrupted a real evaluation.
That claim was wrong and has been removed. The direct experiment:

Running the **oracle baseline** (`dbim_high_order`) on the production provider,
under the **pre-fix** settings (`num_samples=10000`), reproduces the shipped
anchors:

| | Imagenet | edges2handbags | DIODE |
|---|---|---|---|
| recorded anchor | 5.528 | 4.988 | 14.306 |
| measured on the provider | **5.528** (exact) | 5.025 (+0.7 %) | **14.512 (+1.4 %)** |

So the provider's listing order sits in the same regime as the machine the
anchors were measured on. Anchors and submissions have been compared like for
like, and no score has been distorted.

**This PR is therefore hardening, not a bug fix**, and it is not free:

- DIODE cost rises 1.84x (still ~27 % of the 4 h budget)
- the metric scale shifts, so this task's anchors must be re-derived (done here)
  and any historical per-task result measured under the old eval is no longer
  comparable — `tasks/cv-dbm-sampler/edits/replay_*.py` are in that category
- in exchange, a provider whose filesystem returns sorted order would silently
  halve every score on this task, and `tasks-modal/` has never been checked

The defect itself is not in dispute — the 2x2 matrix above is reproducible on one
host — only whether it is worth paying to close a hazard that has not fired.
That is a maintainer call, and the PR is written so it can be closed without loss
if the answer is no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
